### PR TITLE
MSBuild TryCommit feature ported to XML Layer

### DIFF
--- a/Editor/Completion/XmlCompletionCommitManager.cs
+++ b/Editor/Completion/XmlCompletionCommitManager.cs
@@ -49,9 +49,9 @@ namespace MonoDevelop.Xml.Editor.Completion
 					}
 				}
 			case XmlCompletionItemKind.Element: {
-					string insertionText = $"{item.InsertText}></{item.InsertText}>";
+					string insertionText = $"{item.InsertText}></{item.InsertText.Trim (new char[] { '<', '>' })}>";
 					Insert (session, buffer, insertionText);
-					ShiftCaret (session, item.InsertText.Length + 3, XmlCaretDirection.Left);
+					ShiftCaret (session, item.InsertText.Trim (new char[] { '<', '>' }).Length + 3, XmlCaretDirection.Left);
 					return CommitResult.Handled;
 				}
 			case XmlCompletionItemKind.Attribute: {
@@ -155,12 +155,6 @@ namespace MonoDevelop.Xml.Editor.Completion
 					session.TextView.Caret.MoveToNextCaretPosition ();
 				}
 				return;
-			case XmlCaretDirection.Top:
-				//TO DO
-				throw new ArgumentException ($"Unsupported value '{caretDirection}'");
-			case XmlCaretDirection.Down:
-				//TO DO
-				throw new ArgumentException ($"Unsupported value '{caretDirection}'");
 			}
 			return;
 		}

--- a/Editor/Completion/XmlCompletionCommitManager.cs
+++ b/Editor/Completion/XmlCompletionCommitManager.cs
@@ -45,7 +45,7 @@ namespace MonoDevelop.Xml.Editor.Completion
 						ShiftCaret (session, 2, XmlCaretDirection.Left);
 						return CommitResult.Handled;
 					} else {
-						return CommitResult.Unhandled;
+						goto case XmlCompletionItemKind.Element;
 					}
 				}
 			case XmlCompletionItemKind.Element: {
@@ -55,7 +55,7 @@ namespace MonoDevelop.Xml.Editor.Completion
 					return CommitResult.Handled;
 				}
 			case XmlCompletionItemKind.Attribute: {
-					string insertionText = $"{item.InsertText}=" + @"""""";
+					string insertionText = $"{item.InsertText}=\"\"";
 					Insert (session, buffer, insertionText);
 					ShiftCaret (session, 1, XmlCaretDirection.Left);
 					return CommitResult.Handled;
@@ -157,10 +157,10 @@ namespace MonoDevelop.Xml.Editor.Completion
 				return;
 			case XmlCaretDirection.Top:
 				//TO DO
-				return;
+				throw new ArgumentException ($"Unsupported value '{caretDirection}'");
 			case XmlCaretDirection.Down:
 				//TO DO
-				return;
+				throw new ArgumentException ($"Unsupported value '{caretDirection}'");
 			}
 			return;
 		}

--- a/Editor/Completion/XmlCompletionItemExtensions.cs
+++ b/Editor/Completion/XmlCompletionItemExtensions.cs
@@ -177,6 +177,7 @@ namespace MonoDevelop.Xml.Editor.Completion
 	public enum XmlCompletionItemKind
 	{
 		Element,
+		SelfClosingElement,
 		Attribute,
 		AttributeValue,
 		CData,
@@ -185,5 +186,12 @@ namespace MonoDevelop.Xml.Editor.Completion
 		Entity,
 		ClosingTag,
 		MultipleClosingTags
+	}
+	public enum XmlCaretDirection
+	{
+		Left,
+		Right,
+		Top,
+		Down
 	}
 }

--- a/Editor/Completion/XmlCompletionItemExtensions.cs
+++ b/Editor/Completion/XmlCompletionItemExtensions.cs
@@ -190,8 +190,6 @@ namespace MonoDevelop.Xml.Editor.Completion
 	public enum XmlCaretDirection
 	{
 		Left,
-		Right,
-		Top,
-		Down
+		Right
 	}
 }

--- a/Editor/Completion/XmlCompletionTriggering.cs
+++ b/Editor/Completion/XmlCompletionTriggering.cs
@@ -16,7 +16,7 @@ namespace MonoDevelop.Xml.Editor.Completion
 			bool isExplicit = reason == XmlTriggerReason.Invocation;
 			bool isTypedChar = reason == XmlTriggerReason.TypedChar;
 			bool isBackspace = reason == XmlTriggerReason.Backspace;
-			Debug.Assert (!isTypedChar || typedCharacter == '\0');
+			//Debug.Assert (!isTypedChar || typedCharacter == '\0');
 
 			// explicit invocation in element name
 			if (isExplicit && spine.CurrentState is XmlNameState && spine.Nodes.Peek () is XElement el && !el.IsNamed) {

--- a/Editor/Completion/XmlCompletionTriggering.cs
+++ b/Editor/Completion/XmlCompletionTriggering.cs
@@ -16,7 +16,9 @@ namespace MonoDevelop.Xml.Editor.Completion
 			bool isExplicit = reason == XmlTriggerReason.Invocation;
 			bool isTypedChar = reason == XmlTriggerReason.TypedChar;
 			bool isBackspace = reason == XmlTriggerReason.Backspace;
-			Debug.Assert (isTypedChar || typedCharacter != '\0');
+			if (isTypedChar) {
+				Debug.Assert (typedCharacter != '\0');
+			}
 
 			// explicit invocation in element name
 			if (isExplicit && spine.CurrentState is XmlNameState && spine.Nodes.Peek () is XElement el && !el.IsNamed) {

--- a/Editor/Completion/XmlCompletionTriggering.cs
+++ b/Editor/Completion/XmlCompletionTriggering.cs
@@ -16,7 +16,7 @@ namespace MonoDevelop.Xml.Editor.Completion
 			bool isExplicit = reason == XmlTriggerReason.Invocation;
 			bool isTypedChar = reason == XmlTriggerReason.TypedChar;
 			bool isBackspace = reason == XmlTriggerReason.Backspace;
-			//Debug.Assert (!isTypedChar || typedCharacter == '\0');
+			Debug.Assert (isTypedChar || typedCharacter != '\0');
 
 			// explicit invocation in element name
 			if (isExplicit && spine.CurrentState is XmlNameState && spine.Nodes.Peek () is XElement el && !el.IsNamed) {


### PR DESCRIPTION
Porting code of `TryCommit` function in MSBuild layer to XML Layer as suggested in the previous PR: https://github.com/mhutch/MonoDevelop.MSBuildEditor/pull/19

The changes done on MSBuild layer can be found in this [commit](https://github.com/mhutch/MonoDevelop.MSBuildEditor/pull/19/commits/7169a45b9cdb833bcc8fd9417139ce0a10263f74). This is done so that MSBuild layer can communicate with the XML layer of this module.

After this, submodules need to be updated with these latest changes. Not sure, if it happens automatically or not.

