### PR TITLE
Remove XML file extension definitions from core Xml library.

### DIFF
--- a/Editor/XmlContentType.cs
+++ b/Editor/XmlContentType.cs
@@ -48,25 +48,5 @@ namespace MonoDevelop.Xml.Editor
 		[Name (XmlContentTypeNames.Xsd)]
 		[BaseDefinition (XmlContentTypeNames.Xml)]
 		public static readonly ContentTypeDefinition XsdContentTypeDefinition = null;
-
-		[Export]
-		[FileExtension (".xml")]
-		[ContentType (XmlContentTypeNames.Xml)]
-		internal static FileExtensionToContentTypeDefinition XmlFileExtensionDefinition = null;
-
-		[Export]
-		[FileExtension (".xsl")]
-		[ContentType (XmlContentTypeNames.Xslt)]
-		internal static FileExtensionToContentTypeDefinition XslFileExtensionDefinition = null;
-
-		[Export]
-		[FileExtension (".xslt")]
-		[ContentType (XmlContentTypeNames.Xslt)]
-		internal static FileExtensionToContentTypeDefinition XsltFileExtensionDefinition = null;
-
-		[Export]
-		[FileExtension (".xsd")]
-		[ContentType (XmlContentTypeNames.Xsd)]
-		internal static FileExtensionToContentTypeDefinition XsdFileExtensionDefinition = null;
 	}
 }


### PR DESCRIPTION
A host should have a choice whether to associate the XML files with MonoDevelop.Xml. Visual Studio for Mac should define it, but Visual Studio for Windows should not, at least for now.