### PR TITLE
Fix a nullref in incremental logic for GetSpineParser()

### DIFF
--- a/Editor/Parsing/XmlBackgroundParser.cs
+++ b/Editor/Parsing/XmlBackgroundParser.cs
@@ -78,8 +78,7 @@ namespace MonoDevelop.Xml.Editor.Completion
 					var obj = prevParse.XDocument.FindAtOrBeforeOffset (startPos);
 
 					// check for null as there may not be a node before startPos
-					if (obj != null)
-					{
+					if (obj != null) {
 						var state = StateMachine.TryRecreateState (obj, startPos);
 						if (state != null) {
 							LoggingService.LogDebug ($"XML parser recovered {state.Position}/{point.Position} state");

--- a/Editor/Parsing/XmlBackgroundParser.cs
+++ b/Editor/Parsing/XmlBackgroundParser.cs
@@ -76,10 +76,15 @@ namespace MonoDevelop.Xml.Editor.Completion
 				var startPos = Math.Min (point.Position, MaximumCompatiblePosition (prevParse.TextSnapshot, point.Snapshot));
 				if (startPos > 0) {
 					var obj = prevParse.XDocument.FindAtOrBeforeOffset (startPos);
-					var state = StateMachine.TryRecreateState (obj, startPos);
-					if (state != null) {
-						LoggingService.LogDebug ($"XML parser recovered {state.Position}/{point.Position} state");
-						parser = new XmlSpineParser (state, StateMachine);
+
+					// check for null as there may not be a node before startPos
+					if (obj != null)
+					{
+						var state = StateMachine.TryRecreateState (obj, startPos);
+						if (state != null) {
+							LoggingService.LogDebug ($"XML parser recovered {state.Position}/{point.Position} state");
+							parser = new XmlSpineParser (state, StateMachine);
+						}
 					}
 				}
 			}

--- a/Tests/Parser/ParserExtensionTests.cs
+++ b/Tests/Parser/ParserExtensionTests.cs
@@ -37,5 +37,19 @@ namespace MonoDevelop.Xml.Tests.Parser
 
 			Assert.AreEqual (expected, actual);
 		}
+
+		[Test]
+		public void TestIncremental ()
+		{
+			var buffer = Catalog.BufferFactoryService.CreateTextBuffer (" ", ContentType);
+			var parser = XmlBackgroundParser.GetParser (buffer);
+			parser.GetOrProcessAsync (buffer.CurrentSnapshot, default).Wait ();
+
+			buffer.Insert (0, " ");
+			var snapshot = buffer.CurrentSnapshot;
+			var caretPoint = new SnapshotPoint (snapshot, 1);
+
+			var spine = parser.GetSpineParser (caretPoint);
+		}
 	}
 }


### PR DESCRIPTION
During Smart Indent if the file starts with a few empty lines and you ask for a smart indent before the first non-whitespace character FindAtOrBeforeOffset() returns null as there are no nodes before the caret. Handle the case and avoid a nullref.