### PR TITLE
Improve BraceCompletion and overtype behavior

### DIFF
--- a/Tests/Completion/CommitTests.cs
+++ b/Tests/Completion/CommitTests.cs
@@ -146,8 +146,8 @@ namespace MonoDevelop.Xml.Tests.Completion
 
 		[Test]
 		[TestCase (" T\n", "<Hello There=\"$\"")]
-		[TestCase (" T\n\"", "<Hello There=\"\"$")]
-		[TestCase (" T^=", "<Hello There=$")]
+		[TestCase (" T\n\"", "<Hello There=\"$\"")]
+		[TestCase (" T^=", "<Hello There=\"$\"")]
 		[TestCase (" T^=\"", "<Hello There=\"$\"")]
 		[TestCase (" Th^<", "<Hello Th<$")]
 		[TestCase (" Th^ ", "<Hello There $")]


### PR DESCRIPTION
Insert double quotes after pressing =
Ignore typed quote when in ="|" because it was inserted automatically.
Overtype closing quote in ="foo|"

Unfortunately the brace completion in the editor suffers from a problem that brace completion doesn't fully work when in the middle of the line, it was designed to work at the end of the line. For now the behavior is not ideal because it doesn't show the overtype adornments (cyan underlines under the character that will be overtyped if the same character is pressed next). VS renders custom adornments to simulate this behavior. I've logged a bug on the editor backlog to fully support this.

This logic has been shipping in VSMac for the past year and seems to be working generally well.