### PR TITLE
Ensure a full parse when getting the spine parser

### DIFF
--- a/Editor/Parsing/XmlBackgroundParser.cs
+++ b/Editor/Parsing/XmlBackgroundParser.cs
@@ -72,6 +72,11 @@ namespace MonoDevelop.Xml.Editor.Completion
 			XmlSpineParser parser = null;
 
 			var prevParse = LastOutput;
+
+			if (prevParse == null) {
+				prevParse = GetOrProcessAsync (point.Snapshot, CancellationToken.None).Result;
+			}
+
 			if (prevParse != null) {
 				var startPos = Math.Min (point.Position, MaximumCompatiblePosition (prevParse.TextSnapshot, point.Snapshot));
 				if (startPos > 0) {


### PR DESCRIPTION
If we're already going to traverse the entire snapshot, might as well do a proper parse as it's most likely already requested by other services or will be requested soon anyway. Fast forwarding a throw-away spine parser is wasted effort. Better pay a bit more once but have a parse tree ready for everyone else to use.

If we don't do this, we fall through to "XML parser failed to recover any state" anyway.

This has been shipping in VSMac and got some coverage.