### PR TITLE
Bump editor NuGet versions in Tests.csproj

### DIFF
--- a/Tests/MonoDevelop.Xml.Tests.csproj
+++ b/Tests/MonoDevelop.Xml.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net472</TargetFramework>
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
     <NUnitDisableSupportAssemblies>true</NUnitDisableSupportAssemblies>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,5 +32,11 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" Version="16.9.31023.347" />
+    <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="16.9.227" />
+    <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" Version="16.9.227" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.9.60" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I honestly don't remember why these were added, I think it's since we've excluded runtime assets from the Editor.csproj we want to re-add these.

I think we didn't want the runtime assets in Editor.csproj so they don't flow into VSMac.