### PR TITLE
Invoke GetHighlights on subject buffer

### DIFF
--- a/Editor/HighlightReferences/HighlightTagger.cs
+++ b/Editor/HighlightReferences/HighlightTagger.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.Extensions.Logging;
 
 using Microsoft.VisualStudio.Text;
@@ -62,7 +63,12 @@ namespace MonoDevelop.Xml.Editor.HighlightReferences
 		// internal for testing
 		internal async Task<(SnapshotSpan? sourceSpan, SnapshotSpan tagsChangedSpan)?> UpdateHighlightsAsync (CancellationToken cancellationToken = default)
 		{
-			var position = TextView.Caret.Position.BufferPosition;
+			var positioninSubjectBuffer = TextView.GetCaretPoint();
+			if (!positioninSubjectBuffer.HasValue) {
+				return null;
+			}
+
+			var position = positioninSubjectBuffer.Value;
 			var newHighlights = await GetHighlightsAsync (position, cancellationToken).ConfigureAwait (false);
 			sourceSpan = newHighlights.highlights.Length == 0 ? (SnapshotSpan?)null : newHighlights.sourceSpan;
 

--- a/Editor/Roslyn/Extensions/ITextViewExtensions.cs
+++ b/Editor/Roslyn/Extensions/ITextViewExtensions.cs
@@ -34,6 +34,11 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
 			return textView.BufferGraph.MapUpOrDownToBuffer (caret.BufferPosition, subjectBuffer);
 		}
 
+		public static SnapshotPoint? GetCaretPoint(this ITextView textView, string contentType = MonoDevelop.Xml.Editor.XmlContentTypeNames.XmlCore)
+		{
+			return GetCaretPoint (textView, s => s.ContentType.IsOfType(contentType));
+		}
+
 		public static SnapshotPoint? GetCaretPoint (this ITextView textView, Predicate<ITextSnapshot> match)
 		{
 			var caret = textView.Caret.Position;


### PR DESCRIPTION
This shows the general approach, however more work is needed when caret moves or text changes, to find the right snapshot of content type xml, and use that, instead of using the top buffer snapshot.