### PR TITLE
Improve triggering

### DIFF
--- a/Core.Tests/Completion/CompletionTriggerTests.cs
+++ b/Core.Tests/Completion/CompletionTriggerTests.cs
@@ -20,7 +20,7 @@ namespace MonoDevelop.Xml.Tests.Completion
 		//    trigger reason defaults to insertion if typedChar is non-null, else invocation
 		//    length defaults to 0
 		//    if typedChar is provided, it's added to the document text
-		[TestCase ("", XmlCompletionTrigger.ElementWithBracket)]
+		[TestCase ("", XmlCompletionTrigger.ElementValue)]
 		[TestCase("<", XmlCompletionTrigger.Element)]
 		[TestCase("", XmlTriggerReason.Backspace, XmlCompletionTrigger.None)]
 		[TestCase("<", 'a', XmlCompletionTrigger.Element, 1)]

--- a/Core/Completion/XmlCompletionTriggering.cs
+++ b/Core/Completion/XmlCompletionTriggering.cs
@@ -23,7 +23,7 @@ namespace MonoDevelop.Xml.Editor.Completion
 
 			// explicit invocation in element name
 			if (isExplicit && context.CurrentState is XmlNameState && context.CurrentState.Parent is XmlTagState) {
-				int length = context.CurrentStateLength;
+				int length = context.CurrentStateLength + 1; // include the < character
 				return (XmlCompletionTrigger.Element, length);
 			}
 
@@ -108,7 +108,7 @@ namespace MonoDevelop.Xml.Editor.Completion
 				context.CurrentState is XmlTextState
 				|| XmlRootState.IsFree (context)
 			)) {
-				return (XmlCompletionTrigger.ElementWithBracket, 0);
+				return (XmlCompletionTrigger.ElementValue, 0);
 			}
 
 			return (XmlCompletionTrigger.None, 0);
@@ -119,7 +119,7 @@ namespace MonoDevelop.Xml.Editor.Completion
 	{
 		None,
 		Element,
-		ElementWithBracket,
+		ElementValue,
 		Attribute,
 		AttributeValue,
 		Entity,

--- a/Core/Completion/XmlCompletionTriggering.cs
+++ b/Core/Completion/XmlCompletionTriggering.cs
@@ -10,8 +10,9 @@ namespace MonoDevelop.Xml.Editor.Completion
 	class XmlCompletionTriggering
 	{
 		//FIXME: the length should do a readahead to capture the whole token
-		public static (XmlCompletionTrigger kind, int length) GetTrigger (XmlSpineParser parser, XmlTriggerReason reason, char typedCharacter)
+		public static (XmlCompletionTrigger kind, int spanStart, XmlReadForward spanReadForward) GetTrigger (XmlSpineParser parser, XmlTriggerReason reason, char typedCharacter)
 		{
+			int triggerPosition = parser.Position;
 			bool isExplicit = reason == XmlTriggerReason.Invocation;
 			bool isTypedChar = reason == XmlTriggerReason.TypedChar;
 			bool isBackspace = reason == XmlTriggerReason.Backspace;
@@ -23,78 +24,79 @@ namespace MonoDevelop.Xml.Editor.Completion
 
 			// explicit invocation in element name
 			if (isExplicit && context.CurrentState is XmlNameState && context.CurrentState.Parent is XmlTagState) {
-				int length = context.CurrentStateLength + 1; // include the < character
-				return (XmlCompletionTrigger.Element, length);
+				int start = triggerPosition - context.CurrentStateLength;
+				return (XmlCompletionTrigger.ElementName, start, XmlReadForward.XmlName);
 			}
 
 			//auto trigger after < in free space
 			if ((isTypedChar || isBackspace) && XmlRootState.MaybeTag (context)) {
-				return (XmlCompletionTrigger.Element, 0);
+				return (XmlCompletionTrigger.Tag, triggerPosition - 1, XmlReadForward.None);
 			}
 
-			//auto trigger after typing first char after < or fist char of attribute
+			//auto trigger after typing first char after < or first char of attribute
 			if (isTypedChar && context.CurrentStateLength == 1 && context.CurrentState is XmlNameState && XmlChar.IsFirstNameChar (typedCharacter)) {
 				if (context.CurrentState.Parent is XmlTagState) {
-					return (XmlCompletionTrigger.Element, 1);
+					return (XmlCompletionTrigger.ElementName, triggerPosition - 1, XmlReadForward.None);
 				}
 				if (context.CurrentState.Parent is XmlAttributeState) {
-					return (XmlCompletionTrigger.Attribute, 1);
+					return (XmlCompletionTrigger.AttributeName, triggerPosition - 1, XmlReadForward.None);
 				}
+				return (XmlCompletionTrigger.None, 0, XmlReadForward.None);
 			}
 
 			// trigger on explicit invocation after <
 			if (isExplicit && XmlRootState.MaybeTag (context)) {
-				return (XmlCompletionTrigger.Element, 0);
+				return (XmlCompletionTrigger.Tag, triggerPosition - 1, XmlReadForward.TagStart);
 			}
 
 			//doctype/cdata completion, explicit trigger after <! or type ! after <
 			if ((isExplicit || typedCharacter == '!') && XmlRootState.MaybeCDataOrCommentOrDocType (context)) {
-				return (XmlCompletionTrigger.DeclarationOrCDataOrComment, 2);
+				return (XmlCompletionTrigger.DeclarationOrCDataOrComment, triggerPosition, XmlReadForward.None);
 			}
 
 			//explicit trigger in existing doctype
 			if (isExplicit && (XmlRootState.MaybeDocType (context) || context.Nodes.Peek () is XDocType)) {
 				int length = context.CurrentState is XmlRootState ? context.CurrentStateLength : context.Position - ((XDocType)context.Nodes.Peek ()).Span.Start;
-				return (XmlCompletionTrigger.DocType, length);
+				return (XmlCompletionTrigger.DocType, triggerPosition - length, XmlReadForward.DocType);
 			}
 
 			//explicit trigger in attribute name
 			if (isExplicit && context.CurrentState is XmlNameState && context.CurrentState.Parent is XmlAttributeState) {
-				return (XmlCompletionTrigger.Attribute, context.CurrentStateLength);
+				return (XmlCompletionTrigger.AttributeName, triggerPosition - context.CurrentStateLength, XmlReadForward.XmlName);
 			}
 
 			//typed space or explicit trigger in tag
 			if ((isExplicit || typedCharacter == ' ') && XmlTagState.IsFree (context)) {
-				return (XmlCompletionTrigger.Attribute, 0);
+				return (XmlCompletionTrigger.AttributeName, triggerPosition, isExplicit? XmlReadForward.XmlName : XmlReadForward.None);
 			}
 
 			//attribute value completion
 			if (XmlAttributeValueState.GetDelimiterChar (context).HasValue) {
+				if (isExplicit) {
+					return (XmlCompletionTrigger.AttributeValue, triggerPosition - context.CurrentStateLength + 1, XmlReadForward.AttributeValue);
+				}
 				//auto trigger on quote regardless
 				if (context.CurrentStateLength == 1) {
-					return (XmlCompletionTrigger.AttributeValue, 0);
-				}
-				if (isExplicit) {
-					return (XmlCompletionTrigger.AttributeValue, context.CurrentStateLength - 1);
+					return (XmlCompletionTrigger.AttributeValue, triggerPosition, XmlReadForward.None);
 				}
 			}
 
 			//entity completion
 			if (context.CurrentState is XmlTextState || context.CurrentState is XmlAttributeValueState) {
 				if (typedCharacter == '&')
-					return (XmlCompletionTrigger.Entity, 0);
+					return (XmlCompletionTrigger.Entity, triggerPosition - 1, isExplicit? XmlReadForward.Entity : XmlReadForward.None);
 
 				var text = parser.GetContext ().KeywordBuilder;
 
 				if (isBackspace && text.Length > 0 && text[text.Length - 1] == '&') {
-					return (XmlCompletionTrigger.Entity, 0);
+					return (XmlCompletionTrigger.Entity, triggerPosition - 1, isExplicit ? XmlReadForward.Entity : XmlReadForward.None);
 				}
 
 				if (isExplicit) {
 					for (int i = 0; i < text.Length; i++) {
 						var c = text[text.Length - i - 1];
 						if (c == '&') {
-							return (XmlCompletionTrigger.Entity, i);
+							return (XmlCompletionTrigger.Entity, triggerPosition - i - 1, XmlReadForward.Entity);
 						}
 						if (!XmlChar.IsNameChar (c)) {
 							break;
@@ -108,19 +110,36 @@ namespace MonoDevelop.Xml.Editor.Completion
 				context.CurrentState is XmlTextState
 				|| XmlRootState.IsFree (context)
 			)) {
-				return (XmlCompletionTrigger.ElementValue, 0);
+				return (XmlCompletionTrigger.ElementValue, triggerPosition, XmlReadForward.None);
 			}
 
-			return (XmlCompletionTrigger.None, 0);
+			return (XmlCompletionTrigger.None, triggerPosition, XmlReadForward.None);
 		}
+	}
+
+	/// <summary>
+	/// Describes how to read forward from the completion span start to get the completion span
+	/// </summary>
+	enum XmlReadForward
+	{
+		None,
+		XmlName,
+		TagStart,
+		DocType,
+		AttributeValue,
+		Entity
 	}
 
 	enum XmlCompletionTrigger
 	{
 		None,
-		Element,
+
+		/// <summary>An XML tag, which may be an element with leading angle bracket, comment etc</summary> 
+		Tag,
+
+		ElementName,
 		ElementValue,
-		Attribute,
+		AttributeName,
 		AttributeValue,
 		Entity,
 		DocType,

--- a/Core/Parser/XmlParserTextSourceExtensions.cs
+++ b/Core/Parser/XmlParserTextSourceExtensions.cs
@@ -50,6 +50,34 @@ namespace MonoDevelop.Xml.Parser
 			return currentPosition - nameStartPosition;
 		}
 
+		public static int GetAttributeValueLengthAtPosition (this ITextSource text, char delimiter, int attributeStartPosition, int currentPosition, int maximumReadahead = DEFAULT_READAHEAD_LIMIT)
+		{
+			int limit = Math.Min (text.Length, currentPosition + maximumReadahead);
+
+			//try to find the end of the name, but don't go too far
+			for (; currentPosition < limit; currentPosition++) {
+				char c = text[currentPosition];
+				if (XmlChar.IsInvalid (c) || c == '<') {
+					return currentPosition - attributeStartPosition;
+				}
+				switch (delimiter) {
+				case '\'':
+				case '"':
+					if (c == delimiter) {
+						return currentPosition - attributeStartPosition;
+					}
+					break;
+				default:
+					if (XmlChar.IsWhitespace (c)) {
+						return currentPosition - attributeStartPosition;
+					}
+					break;
+				}
+			}
+
+			return currentPosition - attributeStartPosition;
+		}
+
 		/// <summary>
 		/// Advances the parser until the specified object is closed i.e. has a closing tag.
 		/// </summary>

--- a/Core/Parser/XmlParserTextSourceExtensions.cs
+++ b/Core/Parser/XmlParserTextSourceExtensions.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using MonoDevelop.Xml.Dom;
-using MonoDevelop.Xml.Parser;
 
 namespace MonoDevelop.Xml.Parser
 {
@@ -23,29 +22,32 @@ namespace MonoDevelop.Xml.Parser
 		{
 			Debug.Assert (spine.CurrentState is XmlNameState);
 
-			int end = spine.Position;
-			int start = end - spine.CurrentStateLength;
-			int mid = -1;
+			int start = spine.Position - spine.CurrentStateLength;
+			var length = text.GetXNameLengthAtPosition (start, spine.Position, maximumReadahead);
 
-			int limit = Math.Min (text.Length, end + maximumReadahead);
+			string name = text.GetText (start, length);
+
+			int i = name.IndexOf (':');
+			if (i < 0) {
+				return new XName (name);
+			} else {
+				return new XName (name.Substring (0, i), name.Substring (i + 1));
+			}
+		}
+
+		public static int GetXNameLengthAtPosition (this ITextSource text, int nameStartPosition, int currentPosition, int maximumReadahead = DEFAULT_READAHEAD_LIMIT)
+		{
+			int limit = Math.Min (text.Length, currentPosition + maximumReadahead);
 
 			//try to find the end of the name, but don't go too far
-			for (; end < limit; end++) {
-				char c = text[end];
-
-				if (c == ':') {
-					if (mid == -1)
-						mid = end;
-					else
-						break;
-				} else if (!XmlChar.IsNameChar (c))
+			for (; currentPosition < limit; currentPosition++) {
+				char c = text[currentPosition];
+				if (!XmlChar.IsNameChar (c)) {
 					break;
+				}
 			}
 
-			if (mid > 0 && end > mid + 1) {
-				return new XName (text.GetText (start, mid - start), text.GetText (mid + 1, end - mid - 1));
-			}
-			return new XName (text.GetText (start, end - start));
+			return currentPosition - nameStartPosition;
 		}
 
 		/// <summary>

--- a/Editor.Tests/Completion/CompletionTests.cs
+++ b/Editor.Tests/Completion/CompletionTests.cs
@@ -15,8 +15,8 @@ namespace MonoDevelop.Xml.Editor.Tests.Completion
 		{
 			var result = await this.GetCompletionContext ("<$");
 			result.AssertNonEmpty ();
-			result.AssertContains ("Hello");
-			result.AssertContains ("!--");
+			result.AssertContains ("<Hello");
+			result.AssertContains ("<!--");
 		}
 
 		[Test]

--- a/Editor.Tests/Completion/XmlCompletionTestSource.cs
+++ b/Editor.Tests/Completion/XmlCompletionTestSource.cs
@@ -53,7 +53,7 @@ namespace MonoDevelop.Xml.Editor.Tests.Completion
 		{
 		}
 
-		protected override Task<CompletionContext> GetElementCompletionsAsync (
+		protected override Task<IList<CompletionItem>?> GetElementCompletionsAsync (
 			IAsyncCompletionSession session,
 			SnapshotPoint triggerLocation,
 			List<XObject> nodePath,
@@ -62,12 +62,12 @@ namespace MonoDevelop.Xml.Editor.Tests.Completion
 		{
 			var item = new CompletionItem (includeBracket? "<Hello" : "Hello", this)
 				.AddKind (XmlCompletionItemKind.Element);
-			var items = ImmutableArray<CompletionItem>.Empty;
-			items = items.Add (item).AddRange (GetMiscellaneousTags (triggerLocation, nodePath, includeBracket));
-			return Task.FromResult (new CompletionContext (items));
+			var items = new List<CompletionItem> () { item };
+			items.AddRange (GetMiscellaneousTags (triggerLocation, nodePath, includeBracket));
+			return Task.FromResult<IList<CompletionItem>?> (items);
 		}
 
-		protected override Task<CompletionContext> GetAttributeCompletionsAsync (
+		protected override Task<IList<CompletionItem>?> GetAttributeCompletionsAsync (
 			IAsyncCompletionSession session,
 			SnapshotPoint triggerLocation,
 			List<XObject> nodePath,
@@ -78,12 +78,11 @@ namespace MonoDevelop.Xml.Editor.Tests.Completion
 			if (nodePath.LastOrDefault () is XElement xel && xel.NameEquals ("Hello", true)) {
 				var item = new CompletionItem ("There", this)
 					.AddKind (XmlCompletionItemKind.Attribute);
-				var items = ImmutableArray<CompletionItem>.Empty;
-				items = items.Add (item);
-				return Task.FromResult (new CompletionContext (items));
+				var items = new List<CompletionItem> () {  item };
+				return Task.FromResult<IList<CompletionItem>?> (items);
 			}
 
-			return Task.FromResult (CompletionContext.Empty);
+			return Task.FromResult<IList<CompletionItem>?> (null);
 		}
 	}
 }

--- a/Editor/Completion/XmlCompletionCommitManager.cs
+++ b/Editor/Completion/XmlCompletionCommitManager.cs
@@ -53,19 +53,20 @@ namespace MonoDevelop.Xml.Editor.Completion
 			};
 
 			switch (kind) {
-			case XmlCompletionTrigger.Element:
+			case XmlCompletionTrigger.Tag:
+			case XmlCompletionTrigger.ElementName:
 			case XmlCompletionTrigger.ElementValue:
 				// allow using / as a commit char for elements as self-closing elements, but special case disallowing it
 				// in the cases where that could conflict with typing the / at the start of a closing tag
 				if (typedChar == '/') {
 					var span = session.ApplicableToSpan.GetSpan (location.Snapshot);
-					if (span.Length == (kind == XmlCompletionTrigger.Element ? 0 : 1)) {
+					if (span.Length == (kind == XmlCompletionTrigger.ElementName ? 0 : 1)) {
 						return false;
 					}
 				}
 				return Array.IndexOf (tagCommitChars, typedChar) > -1;
 
-			case XmlCompletionTrigger.Attribute:
+			case XmlCompletionTrigger.AttributeName:
 				return Array.IndexOf (attributeCommitChars, typedChar) > -1;
 
 			case XmlCompletionTrigger.AttributeValue:
@@ -81,9 +82,9 @@ namespace MonoDevelop.Xml.Editor.Completion
 			return false;
 		}
 
-		static readonly CommitResult CommitSwallowChar = new CommitResult (true, CommitBehavior.SuppressFurtherTypeCharCommandHandlers);
+		static readonly CommitResult CommitSwallowChar = new (true, CommitBehavior.SuppressFurtherTypeCharCommandHandlers);
 
-		static readonly CommitResult CommitCancel = new CommitResult (true, CommitBehavior.CancelCommit);
+		static readonly CommitResult CommitCancel = new (true, CommitBehavior.CancelCommit);
 
 		public CommitResult TryCommit (IAsyncCompletionSession session, ITextBuffer buffer, CompletionItem item, char typedChar, CancellationToken token)
 		{

--- a/Editor/Completion/XmlCompletionCommitManager.cs
+++ b/Editor/Completion/XmlCompletionCommitManager.cs
@@ -54,7 +54,7 @@ namespace MonoDevelop.Xml.Editor.Completion
 
 			switch (kind) {
 			case XmlCompletionTrigger.Element:
-			case XmlCompletionTrigger.ElementWithBracket:
+			case XmlCompletionTrigger.ElementValue:
 				// allow using / as a commit char for elements as self-closing elements, but special case disallowing it
 				// in the cases where that could conflict with typing the / at the start of a closing tag
 				if (typedChar == '/') {

--- a/Editor/Completion/XmlCompletionCommitManager.cs
+++ b/Editor/Completion/XmlCompletionCommitManager.cs
@@ -92,6 +92,13 @@ namespace MonoDevelop.Xml.Editor.Completion
 				return CommitResult.Unhandled;
 			}
 
+			// per-item CommitCharacters overrides the default commit chars
+			if (!item.CommitCharacters.IsDefaultOrEmpty) {
+				if (item.CommitCharacters.Contains (typedChar)) {
+					return CommitCancel;
+				}
+			}
+
 			var span = session.ApplicableToSpan.GetSpan (buffer.CurrentSnapshot);
 			bool wasTypedInFull = span.Length == item.InsertText.Length;
 

--- a/Editor/Completion/XmlCompletionSource.cs
+++ b/Editor/Completion/XmlCompletionSource.cs
@@ -342,7 +342,12 @@ namespace MonoDevelop.Xml.Editor.Completion
 					continue;
 				}
 
-				var item = new CompletionItem (prefix + name, this, XmlImages.ClosingTag)
+				string insertText = prefix + name;
+
+				// force these to sort last, they're not very interesting values to browse as these tags are most likely already closed
+				string sortText = "ZZZZZZ" + insertText;
+
+				var item = new CompletionItem (insertText, this, XmlImages.ClosingTag, ImmutableArray<CompletionFilter>.Empty, "", insertText, sortText, insertText, ImmutableArray<ImageElement>.Empty)
 					.AddClosingElementDocumentation (el, dedup.Count > 1)
 					.AddKind (dedup.Count == 1? XmlCompletionItemKind.ClosingTag : XmlCompletionItemKind.MultipleClosingTags);
 				item.Properties.AddProperty (typeof (List<XObject>), nodePath);

--- a/Editor/Completion/XmlCompletionSource.cs
+++ b/Editor/Completion/XmlCompletionSource.cs
@@ -53,16 +53,35 @@ namespace MonoDevelop.Xml.Editor.Completion
 			return spineParser;
 		}
 
-		public async virtual Task<CompletionContext> GetCompletionContextAsync (
-			IAsyncCompletionSession session,
-			CompletionTrigger trigger,
-			SnapshotPoint triggerLocation,
-			SnapshotSpan applicableToSpan,
-			CancellationToken token)
+		public async virtual Task<CompletionContext> GetCompletionContextAsync (IAsyncCompletionSession session, CompletionTrigger trigger, SnapshotPoint triggerLocation, SnapshotSpan applicableToSpan, CancellationToken token)
 		{
+			var tasks = GetCompletionTasks (session, trigger, triggerLocation, applicableToSpan, token).ToList ();
+
+			await Task.WhenAll (tasks);
+
+			var allItems = ImmutableArray<CompletionItem>.Empty;
+			foreach (var task in tasks) {
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
+				if (task.Result is IList<CompletionItem> taskItems && taskItems.Count > 0) {
+					allItems = allItems.AddRange (taskItems);
+				}
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
+			}
+
+			if (allItems.IsEmpty) {
+				return CompletionContext.Empty;
+			}
+
+			return new CompletionContext (allItems, null, InitialSelectionHint.SoftSelection);
+		}
+
+		IEnumerable<Task<IList<CompletionItem>?>> GetCompletionTasks (IAsyncCompletionSession session, CompletionTrigger trigger, SnapshotPoint triggerLocation, SnapshotSpan applicableToSpan, CancellationToken token)
+		{
+			yield return GetAdditionalCompletionsAsync (session, trigger, triggerLocation, applicableToSpan, token);
+
 			var reason = ConvertReason (trigger.Reason, trigger.Character);
 			if (reason == null) {
-				return CompletionContext.Empty;
+				yield break;
 			}
 
 			var parser = GetSpineParser (triggerLocation);
@@ -70,65 +89,55 @@ namespace MonoDevelop.Xml.Editor.Completion
 			// FIXME: cache the value from InitializeCompletion somewhere?
 			var (kind, _) = XmlCompletionTriggering.GetTrigger (parser, reason.Value, trigger.Character);
 
-			if (kind != XmlCompletionTrigger.None) {
-				List<XObject> nodePath = parser.GetNodePath (triggerLocation.Snapshot);
+			if (kind == XmlCompletionTrigger.None) {
+				yield break;
+			}
 
-				session.Properties.AddProperty (typeof (XmlCompletionTrigger), kind);
+			List<XObject> nodePath = parser.GetNodePath (triggerLocation.Snapshot);
+			session.Properties.AddProperty (typeof (XmlCompletionTrigger), kind);
 
-				switch (kind) {
-				case XmlCompletionTrigger.Element:
-				case XmlCompletionTrigger.ElementWithBracket:
-					// if we're completing an existing element, remove it from the path
-					// so we don't get completions for its children instead
-					if (nodePath.Count > 0) {
-						if (nodePath[nodePath.Count-1] is XElement leaf && leaf.Name.Length == applicableToSpan.Length) {
-							nodePath.RemoveAt (nodePath.Count - 1);
-						}
+			switch (kind) {
+			case XmlCompletionTrigger.ElementValue:
+				yield return GetElementValueCompletionsAsync (session, triggerLocation, nodePath, token);
+				goto case XmlCompletionTrigger.Element;
+
+			case XmlCompletionTrigger.Element:
+				// if we're completing an existing element, remove it from the path
+				// so we don't get completions for its children instead
+				if (nodePath.Count > 0) {
+					if (nodePath[nodePath.Count - 1] is XElement leaf && leaf.Name.Length == applicableToSpan.Length) {
+						nodePath.RemoveAt (nodePath.Count - 1);
 					}
-					//TODO: if it's on the first or second line and there's no DTD declaration, add the DTDs, or at least <!DOCTYPE
-					//TODO: add snippets // MonoDevelop.Ide.CodeTemplates.CodeTemplateService.AddCompletionDataForFileName (DocumentContext.Name, list);
-					return await GetElementCompletionsAsync (session, triggerLocation, nodePath, kind == XmlCompletionTrigger.ElementWithBracket, token);
-
-				case XmlCompletionTrigger.Attribute:
-					if (parser.Spine.TryFind<IAttributedXObject> (maxDepth: 1) is not IAttributedXObject attributedOb) {
-						throw new InvalidOperationException ("Did not find IAttributedXObject in stack for XmlCompletionTrigger.Attribute");
-					}
-					parser.Clone ().AdvanceUntilEnded ((XObject)attributedOb, triggerLocation.Snapshot, 1000);
-					var attributes = attributedOb.Attributes.ToDictionary (StringComparer.OrdinalIgnoreCase);
-					return await GetAttributeCompletionsAsync (session, triggerLocation, nodePath, attributedOb, attributes, token);
-
-				case XmlCompletionTrigger.AttributeValue:
-					if (parser.Spine.TryPeek (out XAttribute? att) && parser.Spine.TryPeek (1, out IAttributedXObject? attributedObject)) {
-						return await GetAttributeValueCompletionsAsync (session, triggerLocation, nodePath, attributedObject, att, token);
-					}
-					break;
-
-				case XmlCompletionTrigger.Entity:
-					return await GetEntityCompletionsAsync (session, triggerLocation, nodePath, token);
-
-				case XmlCompletionTrigger.DocType:
-				case XmlCompletionTrigger.DeclarationOrCDataOrComment:
-					return await GetDeclarationCompletionsAsync (session, triggerLocation, nodePath, token);
 				}
-			}
-
-			return CompletionContext.Empty;
-		}
-
-		static XmlTriggerReason? ConvertReason (CompletionTriggerReason reason, char typedChar)
-		{
-			switch (reason) {
-			case CompletionTriggerReason.Insertion:
-				if (typedChar != '\0')
-					return XmlTriggerReason.TypedChar;
+				//TODO: if it's on the first or second line and there's no DTD declaration, add the DTDs, or at least <!DOCTYPE
+				//TODO: add snippets // MonoDevelop.Ide.CodeTemplates.CodeTemplateService.AddCompletionDataForFileName (DocumentContext.Name, list);
+				yield return GetElementCompletionsAsync (session, triggerLocation, nodePath, reason == XmlTriggerReason.Invocation, token);
 				break;
-			case CompletionTriggerReason.Backspace:
-				return XmlTriggerReason.Backspace;
-			case CompletionTriggerReason.Invoke:
-			case CompletionTriggerReason.InvokeAndCommitIfUnique:
-				return XmlTriggerReason.Invocation;
+
+			case XmlCompletionTrigger.Attribute:
+				if (parser.Spine.TryFind<IAttributedXObject> (maxDepth: 1) is not IAttributedXObject attributedOb) {
+					throw new InvalidOperationException ("Did not find IAttributedXObject in stack for XmlCompletionTrigger.Attribute");
+				}
+				parser.Clone ().AdvanceUntilEnded ((XObject)attributedOb, triggerLocation.Snapshot, 1000);
+				var attributes = attributedOb.Attributes.ToDictionary (StringComparer.OrdinalIgnoreCase);
+				yield return GetAttributeCompletionsAsync (session, triggerLocation, nodePath, attributedOb, attributes, token);
+				break;
+
+			case XmlCompletionTrigger.AttributeValue:
+				if (parser.Spine.TryPeek (out XAttribute? att) && parser.Spine.TryPeek (1, out IAttributedXObject? attributedObject)) {
+					yield return GetAttributeValueCompletionsAsync (session, triggerLocation, nodePath, attributedObject, att, token);
+				}
+				break;
+
+			case XmlCompletionTrigger.Entity:
+				yield return GetEntityCompletionsAsync (session, triggerLocation, nodePath, token);
+				break;
+
+			case XmlCompletionTrigger.DocType:
+			case XmlCompletionTrigger.DeclarationOrCDataOrComment:
+				yield return GetDeclarationCompletionsAsync (session, triggerLocation, nodePath, token);
+				break;
 			}
-			return null;
 		}
 
 		public virtual Task<object> GetDescriptionAsync (
@@ -163,17 +172,16 @@ namespace MonoDevelop.Xml.Editor.Completion
 		[LoggerMessage (EventId = 2, Level = LogLevel.Trace, Message = "Attempting completion for state '{state}'x{currentSpineLength}, character='{triggerChar}', trigger='{triggerReason}'")]
 		static partial void LogAttemptingCompletion (ILogger logger, XmlParserState state, int currentSpineLength, char triggerChar, CompletionTriggerReason triggerReason);
 
-
-		protected virtual Task<CompletionContext> GetElementCompletionsAsync (
+		protected virtual Task<IList<CompletionItem>?> GetElementCompletionsAsync (
 			IAsyncCompletionSession session,
 			SnapshotPoint triggerLocation,
 			List<XObject> nodePath,
 			bool includeBracket,
 			CancellationToken token
 			)
-			=> Task.FromResult (CompletionContext.Empty);
+			=> Task.FromResult<IList<CompletionItem>?> (null);
 
-		protected virtual Task<CompletionContext> GetAttributeCompletionsAsync (
+		protected virtual Task<IList<CompletionItem>?> GetAttributeCompletionsAsync (
 			IAsyncCompletionSession session,
 			SnapshotPoint triggerLocation,
 			List<XObject> nodePath,
@@ -181,9 +189,9 @@ namespace MonoDevelop.Xml.Editor.Completion
 			Dictionary<string, string> existingAtts,
 			CancellationToken token
 			)
-			=> Task.FromResult (CompletionContext.Empty);
+			=> Task.FromResult<IList<CompletionItem>?> (null);
 
-		protected virtual Task<CompletionContext> GetAttributeValueCompletionsAsync (
+		protected virtual Task<IList<CompletionItem>?> GetAttributeValueCompletionsAsync (
 			IAsyncCompletionSession session,
 			SnapshotPoint triggerLocation,
 			List<XObject> nodePath,
@@ -191,32 +199,56 @@ namespace MonoDevelop.Xml.Editor.Completion
 			XAttribute attribute,
 			CancellationToken token
 			)
-			=> Task.FromResult (CompletionContext.Empty);
+			=> Task.FromResult<IList<CompletionItem>?> (null);
 
-		protected virtual Task<CompletionContext> GetEntityCompletionsAsync (
+		protected virtual Task<IList<CompletionItem>?> GetEntityCompletionsAsync (
 			IAsyncCompletionSession session,
 			SnapshotPoint triggerLocation,
 			List<XObject> nodePath,
 			CancellationToken token
 			)
-			=> Task.FromResult (CreateCompletionContext (GetBuiltInEntityItems ()));
+			=> Task.FromResult<IList<CompletionItem>?> (null);
 
-		protected virtual Task<CompletionContext> GetDeclarationCompletionsAsync (
+		protected virtual Task<IList<CompletionItem>?> GetDeclarationCompletionsAsync (
 			IAsyncCompletionSession session,
 			SnapshotPoint triggerLocation,
 			List<XObject> nodePath,
 			CancellationToken token
 			)
-			=> Task.FromResult (
-				CreateCompletionContext (
-					nodePath.Any (n => n is XElement)
-						? new [] { cdataItemWithBracket, commentItemWithBracket }
-						: new [] { commentItemWithBracket }
-					)
+			=> Task.FromResult<IList<CompletionItem>?> (
+				nodePath.Any (n => n is XElement)
+					? new [] { cdataItemWithBracket, commentItemWithBracket }
+					: new [] { commentItemWithBracket }
 				);
 
-		static CompletionContext CreateCompletionContext (IEnumerable<CompletionItem> items)
-			=> new (ImmutableArray<CompletionItem>.Empty.AddRange (items), null, InitialSelectionHint.SoftSelection);
+		protected virtual Task<IList<CompletionItem>?> GetElementValueCompletionsAsync (
+			IAsyncCompletionSession session,
+			SnapshotPoint triggerLocation,
+			List<XObject> nodePath,
+			CancellationToken token) => Task.FromResult<IList<CompletionItem>?> (null);
+
+		protected virtual Task<IList<CompletionItem>?> GetAdditionalCompletionsAsync (
+			IAsyncCompletionSession session,
+			CompletionTrigger trigger,
+			SnapshotPoint triggerLocation,
+			SnapshotSpan applicableToSpan,
+			CancellationToken token) => Task.FromResult<IList<CompletionItem>?> (null);
+
+		static XmlTriggerReason? ConvertReason (CompletionTriggerReason reason, char typedChar)
+		{
+			switch (reason) {
+			case CompletionTriggerReason.Insertion:
+				if (typedChar != '\0')
+					return XmlTriggerReason.TypedChar;
+				break;
+			case CompletionTriggerReason.Backspace:
+				return XmlTriggerReason.Backspace;
+			case CompletionTriggerReason.Invoke:
+			case CompletionTriggerReason.InvokeAndCommitIfUnique:
+				return XmlTriggerReason.Invocation;
+			}
+			return null;
+		}
 
 		CompletionItem cdataItem, commentItem, prologItem;
 		CompletionItem cdataItemWithBracket, commentItemWithBracket, prologItemWithBracket;

--- a/Editor/Logging/EditorLoggerFactoryExtensions.cs
+++ b/Editor/Logging/EditorLoggerFactoryExtensions.cs
@@ -14,13 +14,13 @@ public static class EditorLoggerFactoryExtensions
 	/// Get a logger for the <paramref name="buffer"/> if it exists, reusing the existing logger if possible, and creating one if necessary.
 	/// </summary>
 	public static ILogger<T> GetLogger<T> (this IEditorLoggerFactory factory, ITextBuffer buffer)
-		=> buffer.Properties.GetOrCreateSingletonProperty (typeof (T), () => factory.CreateLogger<T> (buffer));
+		=> buffer.Properties.GetOrCreateSingletonProperty (typeof (ILogger<T>), () => factory.CreateLogger<T> (buffer));
 
 	/// <summary>
 	/// Get a logger for the <paramref name="textView"/>, reusing the existing logger if possible, and creating one if necessary.
 	/// </summary>
 	public static ILogger<T> GetLogger<T> (this IEditorLoggerFactory factory, ITextView textView)
-		=> textView.Properties.GetOrCreateSingletonProperty (typeof (T), () => factory.CreateLogger<T> (textView));
+		=> textView.Properties.GetOrCreateSingletonProperty (typeof (ILogger<T>), () => factory.CreateLogger<T> (textView));
 
 	/// <summary>
 	/// Create a logger for the <paramref name="buffer"/>.

--- a/Editor/XmlParserSnapshotExtensions.cs
+++ b/Editor/XmlParserSnapshotExtensions.cs
@@ -3,8 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+
 using Microsoft.VisualStudio.Text;
+
 using MonoDevelop.Xml.Dom;
 using MonoDevelop.Xml.Parser;
 


### PR DESCRIPTION
XML triggering now calculates the span to which the completion is applicable, so ctrl-space in a symbol will properly overwrite the symbol instead of prepending.