### PR TITLE
Log exceptions before bubbling to editor

### DIFF
--- a/Core/Logging/LoggerExtensions.cs
+++ b/Core/Logging/LoggerExtensions.cs
@@ -12,32 +12,86 @@ namespace MonoDevelop.Xml.Logging;
 
 public static partial class LoggerExtensions
 {
-	public static void CatchAndLogWarning (this Task task, ILogger logger, [CallerMemberName] string? originMember = default)
+	/// <summary>
+	/// Logs any exceptions thrown by the task, and observes the task so it doesn't throw unobserved exceptions.
+	/// </summary>
+	public static void LogExceptionsAndForget (this Task task, ILogger logger, [CallerMemberName] string? originMember = default)
+	{
+		task.CatchAndLogIfFaulted (logger, originMember);
+	}
+
+	public static Task<T> WithExceptionLogger<T> (this Task<T> task, ILogger logger, [CallerMemberName] string? originMember = default)
+	{
+		task.CatchAndLogIfFaulted (logger, originMember);
+		return task;
+	}
+
+	/// <summary>
+	/// Attaches a continution to the task that logs any exception thrown by the task, and returns the task.
+	/// </summary>
+	public static Task WithExceptionLogger (this Task task, ILogger logger, [CallerMemberName] string? originMember = default)
+	{
+		task.CatchAndLogIfFaulted (logger, originMember);
+		return task;
+	}
+
+	static Task CatchAndLogIfFaulted (this Task task, ILogger logger, string? originMember)
 	{
 		if (originMember is null) {
 			throw new ArgumentNullException (nameof (originMember));
 		}
 
 		_ = task.ContinueWith (
-			t => {
-				List<Exception>? unhandled = null;
-				foreach (var inner in t.Exception!.InnerExceptions) {
-					if (inner is not OperationCanceledException) {
-						(unhandled ??= new List<Exception> ()).Add (inner);
-					}
-				}
-				if (unhandled is null) {
-					return;
-				}
-				Exception ex = unhandled.Count == 1 ? unhandled[0] : new AggregateException (unhandled);
-				logger.LogInternalErrorAsWarning (ex, originMember);
-			},
+			t => LogExceptions (logger, originMember, t),
 			default,
 			TaskContinuationOptions.OnlyOnFaulted,
 			TaskScheduler.Default
 		);
+
+		return task;
 	}
 
-	[LoggerMessage (Level = LogLevel.Warning, Message = "Internal error in {originMember}")]
-	public static partial void LogInternalErrorAsWarning (this ILogger logger, Exception ex, string originMember);
+	static void LogExceptions (ILogger logger, string originMember, Task t)
+	{
+		if (t.Exception is null) {
+			return;
+		}
+		List<Exception>? unhandled = null;
+		foreach (var inner in t.Exception.InnerExceptions) {
+			if (inner is not OperationCanceledException) {
+				(unhandled ??= new List<Exception> ()).Add (inner);
+			}
+		}
+		if (unhandled is null) {
+			return;
+		}
+		Exception ex = unhandled.Count == 1 ? unhandled[0] : new AggregateException (unhandled);
+		logger.LogInternalError (ex, originMember);
+	}
+
+	/// <summary>
+	/// Logs an unhandled exception.
+	/// </summary>
+	public static void LogInternalError (this ILogger logger, Exception ex, [CallerMemberName] string? originMember = default)
+		=> logger.LogInternalErrorInMember (ex, originMember ?? throw new ArgumentNullException (nameof (originMember)));
+
+	[LoggerMessage (Level = LogLevel.Error, Message = "Internal error in {originMember}")]
+	static partial void LogInternalErrorInMember (this ILogger logger, Exception ex, string originMember);
+
+	/// <summary>
+	/// Catches any exception thrown by the function, logs it, and rethrows. If the function returns a task that faults, its exception will also be logged.
+	/// </summary>
+	public static T InvokeAndLogErrors<T> (this ILogger logger, Func<T> function, [CallerMemberName] string? originMember = default)
+	{
+		try {
+			var result = function ();
+			if (result is Task task) {
+				task.CatchAndLogIfFaulted (logger, originMember);
+			}
+			return result;
+		} catch (Exception ex) {
+			logger.LogInternalError (ex, originMember);
+			throw;
+		}
+	}
 }

--- a/Editor/BraceCompletion/XmlBraceCompletionCommandHandler.cs
+++ b/Editor/BraceCompletion/XmlBraceCompletionCommandHandler.cs
@@ -59,6 +59,9 @@ namespace MonoDevelop.Xml.Editor.BraceCompletion
 		public CommandState GetCommandState (TypeCharCommandArgs args, Func<CommandState> nextCommandHandler) => nextCommandHandler ();
 
 		public void ExecuteCommand (TypeCharCommandArgs args, Action nextCommandHandler, CommandExecutionContext executionContext)
+			=> ExecuteCommandInternal (args, nextCommandHandler, executionContext);
+
+		void ExecuteCommandInternal (TypeCharCommandArgs args, Action nextCommandHandler, CommandExecutionContext executionContext)
 		{
 			var openingPoint = args.TextView.Caret.Position.BufferPosition;
 

--- a/Editor/Completion/XmlCompletionCommitManager.cs
+++ b/Editor/Completion/XmlCompletionCommitManager.cs
@@ -40,6 +40,9 @@ namespace MonoDevelop.Xml.Editor.Completion
 		public IEnumerable<char> PotentialCommitCharacters => allCommitChars;
 
 		public bool ShouldCommitCompletion (IAsyncCompletionSession session, SnapshotPoint location, char typedChar, CancellationToken token)
+			=> logger.InvokeAndLogErrors (() => ShouldCommitCompletionInternal (session, location, typedChar, token));
+
+		bool ShouldCommitCompletionInternal (IAsyncCompletionSession session, SnapshotPoint location, char typedChar, CancellationToken token)
 		{
 			if (Array.IndexOf (allCommitChars, typedChar) < 0) {
 				return false;
@@ -87,6 +90,9 @@ namespace MonoDevelop.Xml.Editor.Completion
 		static readonly CommitResult CommitCancel = new (true, CommitBehavior.CancelCommit);
 
 		public CommitResult TryCommit (IAsyncCompletionSession session, ITextBuffer buffer, CompletionItem item, char typedChar, CancellationToken token)
+			=> logger.InvokeAndLogErrors (() => TryCommitInternal (session, buffer, item, typedChar, token));
+
+		public CommitResult TryCommitInternal (IAsyncCompletionSession session, ITextBuffer buffer, CompletionItem item, char typedChar, CancellationToken token)
 		{
 			if (!item.TryGetKind (out var kind)) {
 				return CommitResult.Unhandled;
@@ -191,7 +197,7 @@ namespace MonoDevelop.Xml.Editor.Completion
 				await provider.JoinableTaskContext.Factory.SwitchToMainThreadAsync ();
 				provider.CommandServiceFactory.GetService (textView).Execute ((v, b) => new Microsoft.VisualStudio.Text.Editor.Commanding.Commands.InvokeCompletionListCommandArgs (v, b), null);
 			});
-			task.CatchAndLogWarning (logger);
+			task.LogExceptionsAndForget (logger);
 		}
 
 		static void ConsumeTrailingChar (ref SnapshotSpan span, char charToConsume)

--- a/Editor/Completion/XmlCompletionSource.cs
+++ b/Editor/Completion/XmlCompletionSource.cs
@@ -142,13 +142,7 @@ namespace MonoDevelop.Xml.Editor.Completion
 			}
 		}
 
-		public virtual Task<object> GetDescriptionAsync (
-			IAsyncCompletionSession session,
-			CompletionItem item,
-			CancellationToken token)
-		{
-			return item.GetDocumentationAsync (session, token);
-		}
+		public virtual Task<object> GetDescriptionAsync (IAsyncCompletionSession session, CompletionItem item, CancellationToken token) => item.GetDocumentationAsync (session, token);
 
 		public virtual CompletionStartData InitializeCompletion (CompletionTrigger trigger, SnapshotPoint triggerLocation, CancellationToken token)
 		{

--- a/Editor/HighlightReferences/HighlightTagger.cs
+++ b/Editor/HighlightReferences/HighlightTagger.cs
@@ -91,12 +91,12 @@ namespace MonoDevelop.Xml.Editor.HighlightReferences
 				await JoinableTaskContext.Factory.SwitchToMainThreadAsync (token);
 				TagsChanged?.Invoke (this, new SnapshotSpanEventArgs (updateSpan));
 			}, token)
-				.CatchAndLogWarning (Logger, "HighlightTagger.TimerFired");
+			.LogExceptionsAndForget (Logger, "HighlightTagger.TimerFired");
 		}
 
-		readonly object highlightsLocker = new object ();
-		ImmutableArray<(TKind kind, SnapshotSpan location)> highlights
-			= ImmutableArray<(TKind kind, SnapshotSpan location)>.Empty;
+		readonly object highlightsLocker = new ();
+
+		ImmutableArray<(TKind kind, SnapshotSpan location)> highlights = ImmutableArray<(TKind kind, SnapshotSpan location)>.Empty;
 		ITextSnapshot highlightedSnapshot;
 		SnapshotSpan? sourceSpan;
 

--- a/Editor/HighlightReferences/XmlHighlightEndTagTagger.cs
+++ b/Editor/HighlightReferences/XmlHighlightEndTagTagger.cs
@@ -22,9 +22,7 @@ namespace MonoDevelop.MSBuild.Editor.HighlightReferences
 	{
 		readonly XmlParserProvider parserProvider;
 
-		public XmlHighlightEndTagTagger (
-			ITextView textView, XmlHighlightEndTagTaggerProvider provider, ILogger logger
-			)
+		public XmlHighlightEndTagTagger (ITextView textView, XmlHighlightEndTagTaggerProvider provider, ILogger logger)
 			: base (textView, provider.JoinableTaskContext, logger)
 		{
 			parserProvider = provider.ParserProvider;

--- a/Editor/Outlining/StructureTagger.cs
+++ b/Editor/Outlining/StructureTagger.cs
@@ -36,6 +36,9 @@ namespace MonoDevelop.Xml.Editor.Tagging
 		public event EventHandler<SnapshotSpanEventArgs>? TagsChanged;
 
 		public IEnumerable<ITagSpan<IStructureTag>> GetTags (NormalizedSnapshotSpanCollection spans)
+			=> logger.InvokeAndLogErrors (() => GetTagsInternal (spans));
+
+		IEnumerable<ITagSpan<IStructureTag>> GetTagsInternal (NormalizedSnapshotSpanCollection spans)
 		{
 			if (spans.Count == 0) {
 				return emptyTagList;
@@ -52,7 +55,7 @@ namespace MonoDevelop.Xml.Editor.Tagging
 			} else {
 				parseTask.ContinueWith (t => {
 					RaiseTagsChanged ();
-				}, TaskScheduler.Default).CatchAndLogWarning (logger);
+				}, TaskScheduler.Default).LogExceptionsAndForget (logger);
 			}
 
 			return emptyTagList;

--- a/Editor/Parsing/BackgroundParseServiceProvider.cs
+++ b/Editor/Parsing/BackgroundParseServiceProvider.cs
@@ -68,7 +68,7 @@ public sealed class BackgroundParseServiceProvider
 		public void RegisterBackgroundOperation (Task task)
 		{
 			int taskCount = Interlocked.Increment (ref runningTasks);
-			task.ContinueWith (OperationCompleted, TaskScheduler.Default).CatchAndLogWarning (logger);
+			task.ContinueWith (OperationCompleted, TaskScheduler.Default).LogExceptionsAndForget (logger);
 
 			if (taskCount == 1 || taskCount == 0) {
 				RunningStateChanged?.Invoke (this, EventArgs.Empty);

--- a/Editor/SmartIndent/XmlSmartIndentProvider.cs
+++ b/Editor/SmartIndent/XmlSmartIndentProvider.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
 
+using MonoDevelop.Xml.Editor.Logging;
 using MonoDevelop.Xml.Editor.Parsing;
 
 namespace MonoDevelop.Xml.Editor.SmartIndent
@@ -15,16 +16,21 @@ namespace MonoDevelop.Xml.Editor.SmartIndent
 	class XmlSmartIndentProvider : ISmartIndentProvider
 	{
 		readonly XmlParserProvider parserProvider;
+		readonly IEditorLoggerFactory loggerFactory;
 
 		[ImportingConstructor]
-		public XmlSmartIndentProvider (XmlParserProvider parserProvider)
+		public XmlSmartIndentProvider (XmlParserProvider parserProvider, IEditorLoggerFactory loggerFactory)
 		{
 			this.parserProvider = parserProvider;
+			this.loggerFactory = loggerFactory;
 		}
 
 		public ISmartIndent CreateSmartIndent (ITextView textView)
 		{
-			return textView.Properties.GetOrCreateSingletonProperty (() => new XmlSmartIndent (textView, parserProvider));
+			return textView.Properties.GetOrCreateSingletonProperty (() => {
+				var logger = loggerFactory.CreateLogger<XmlSmartIndent> (textView);
+				return new XmlSmartIndent (textView, parserProvider, logger);
+			});
 		}
 	}
 }

--- a/Editor/TextStructure/XmlTextStructureNavigatorProvider.cs
+++ b/Editor/TextStructure/XmlTextStructureNavigatorProvider.cs
@@ -9,6 +9,8 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Operations;
 
 using Microsoft.VisualStudio.Utilities;
+
+using MonoDevelop.Xml.Editor.Logging;
 using MonoDevelop.Xml.Editor.Parsing;
 
 namespace MonoDevelop.Xml.Editor.TextStructure
@@ -20,16 +22,19 @@ namespace MonoDevelop.Xml.Editor.TextStructure
 		public ITextStructureNavigatorSelectorService NavigatorService { get; }
 		public IContentTypeRegistryService ContentTypeRegistry { get; }
 		public XmlParserProvider ParserProvider { get; }
+		public IEditorLoggerFactory LoggerFactory { get; }
 
 		[ImportingConstructor]
 		public XmlTextStructureNavigatorProvider (
 			ITextStructureNavigatorSelectorService navigatorService,
 			IContentTypeRegistryService contentTypeRegistry,
-			XmlParserProvider parserProvider)
+			XmlParserProvider parserProvider,
+			IEditorLoggerFactory loggerFactory)
 		{
 			NavigatorService = navigatorService;
 			ContentTypeRegistry = contentTypeRegistry;
 			ParserProvider = parserProvider;
+			LoggerFactory = loggerFactory;
 		}
 
 		public ITextStructureNavigator CreateTextStructureNavigator (ITextBuffer textBuffer)


### PR DESCRIPTION
Add exception logging at all the points the editor calls into the exception. The exceptions will still reach the editor, and will be signalled to the user.