### PR TITLE
Add extensible context on XmlCompletionSource

### DIFF
--- a/Core/Completion/XmlCompletionTriggering.cs
+++ b/Core/Completion/XmlCompletionTriggering.cs
@@ -220,6 +220,7 @@ namespace MonoDevelop.Xml.Editor.Completion
 	{
 		Invocation,
 		TypedChar,
-		Backspace
+		Backspace,
+		Unknown
 	}
 }

--- a/Editor.Tests/Completion/XmlCompletionTestSource.cs
+++ b/Editor.Tests/Completion/XmlCompletionTestSource.cs
@@ -21,6 +21,7 @@ using MonoDevelop.Xml.Dom;
 using MonoDevelop.Xml.Editor.Completion;
 using MonoDevelop.Xml.Editor.Logging;
 using MonoDevelop.Xml.Editor.Parsing;
+using MonoDevelop.Xml.Parser;
 
 namespace MonoDevelop.Xml.Editor.Tests.Completion
 {
@@ -47,35 +48,24 @@ namespace MonoDevelop.Xml.Editor.Tests.Completion
 		}
 	}
 
-	class XmlCompletionTestSource : XmlCompletionSource
+	class XmlCompletionTestSource : XmlCompletionSource<XmlCompletionTriggerContext>
 	{
 		public XmlCompletionTestSource (ITextView textView, ILogger logger, XmlParserProvider parserProvider) : base (textView, logger, parserProvider)
 		{
 		}
 
-		protected override Task<IList<CompletionItem>?> GetElementCompletionsAsync (
-			IAsyncCompletionSession session,
-			SnapshotPoint triggerLocation,
-			List<XObject> nodePath,
-			bool includeBracket,
-			CancellationToken token)
+		protected override Task<IList<CompletionItem>?> GetElementCompletionsAsync (XmlCompletionTriggerContext context, bool includeBracket, CancellationToken token)
 		{
 			var item = new CompletionItem (includeBracket? "<Hello" : "Hello", this)
 				.AddKind (XmlCompletionItemKind.Element);
 			var items = new List<CompletionItem> () { item };
-			items.AddRange (GetMiscellaneousTags (triggerLocation, nodePath, includeBracket));
+			items.AddRange (GetMiscellaneousTags (context.TriggerLocation, context.NodePath, includeBracket));
 			return Task.FromResult<IList<CompletionItem>?> (items);
 		}
 
-		protected override Task<IList<CompletionItem>?> GetAttributeCompletionsAsync (
-			IAsyncCompletionSession session,
-			SnapshotPoint triggerLocation,
-			List<XObject> nodePath,
-			IAttributedXObject attributedObject,
-			Dictionary<string, string> existingAtts,
-			CancellationToken token)
+		protected override Task<IList<CompletionItem>?> GetAttributeCompletionsAsync (XmlCompletionTriggerContext context, IAttributedXObject attributedObject, Dictionary<string, string> existingAtts, CancellationToken token)
 		{
-			if (nodePath.LastOrDefault () is XElement xel && xel.NameEquals ("Hello", true)) {
+			if (context.NodePath.LastOrDefault () is XElement xel && xel.NameEquals ("Hello", true)) {
 				var item = new CompletionItem ("There", this)
 					.AddKind (XmlCompletionItemKind.Attribute);
 				var items = new List<CompletionItem> () {  item };
@@ -84,5 +74,8 @@ namespace MonoDevelop.Xml.Editor.Tests.Completion
 
 			return Task.FromResult<IList<CompletionItem>?> (null);
 		}
+
+		protected override XmlCompletionTriggerContext CreateTriggerContext (IAsyncCompletionSession session, CompletionTrigger trigger, XmlSpineParser spineParser, SnapshotPoint triggerLocation, SnapshotSpan applicableToSpan)
+			=> new (session, triggerLocation, spineParser, trigger, applicableToSpan);
 	}
 }

--- a/Editor.Tests/XmlTestEnvironment.cs
+++ b/Editor.Tests/XmlTestEnvironment.cs
@@ -110,7 +110,7 @@ namespace MonoDevelop.Xml.Editor.Tests
 
 		protected virtual IEnumerable<string> GetAssembliesToCompose () => new[] {
 			typeof (XmlParser).Assembly.Location,
-			typeof (XmlCompletionSource).Assembly.Location,
+			typeof (XmlCompletionSource<>).Assembly.Location,
 			typeof (XmlTestEnvironment).Assembly.Location
 		};
 

--- a/Editor/Completion/XmlCompletionTriggerContext.cs
+++ b/Editor/Completion/XmlCompletionTriggerContext.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+#if NETFRAMEWORK
+#nullable disable warnings
+#endif
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
+using Microsoft.VisualStudio.Text;
+
+using MonoDevelop.Xml.Dom;
+using MonoDevelop.Xml.Parser;
+
+namespace MonoDevelop.Xml.Editor.Completion;
+
+/// <summary>
+/// Encapsulates the context of completion triggering in <see cref="XmlCompletionSource{TTriggerContext}"/> so that
+/// subclassed completion sources can augment it with additional information.
+/// </summary>
+public class XmlCompletionTriggerContext
+{
+	public XmlCompletionTriggerContext (IAsyncCompletionSession session, SnapshotPoint triggerLocation, XmlSpineParser spineParser, CompletionTrigger trigger, SnapshotSpan applicableToSpan)
+	{
+		Session = session;
+		TriggerLocation = triggerLocation;
+		SpineParser = spineParser;
+		Trigger = trigger;
+		ApplicableToSpan = applicableToSpan;
+
+		XmlTriggerReason = ConvertReason (trigger.Reason, trigger.Character);
+
+		// FIXME: cache the value from InitializeCompletion somewhere?
+		XmlTriggerKind = XmlCompletionTriggering.GetTrigger (spineParser, XmlTriggerReason, trigger.Character);
+	}
+
+	/// <summary>
+	/// Initializes the node path. Only called if <see cref="IsSupportedTriggerReason"/> is true.
+	/// </summary>
+	public virtual Task InitializeNodePath (ILogger logger, CancellationToken cancellationToken)
+	{
+		SpineParser.TryGetNodePath (TriggerLocation.Snapshot, out List<XObject>? nodePath, cancellationToken: cancellationToken);
+		NodePath = nodePath;
+
+		// if we're completing an existing element, remove it from the path
+		// so we don't get completions for its children instead
+		if ((XmlTriggerKind == XmlCompletionTrigger.ElementName || XmlTriggerKind == XmlCompletionTrigger.Tag) && nodePath.Count > 0) {
+			if (nodePath[nodePath.Count - 1] is XElement leaf && leaf.Name.Length == ApplicableToSpan.Length) {
+				nodePath.RemoveAt (nodePath.Count - 1);
+			}
+		}
+
+		return Task.CompletedTask;
+	}
+
+	/// <summary>
+	/// Whether the <see cref="CompletionTriggerReason"/> is supported by this completion source.
+	/// </summary>
+	public virtual bool IsSupportedTriggerReason => XmlTriggerKind != XmlCompletionTrigger.None;
+
+	public IAsyncCompletionSession Session { get; }
+	public SnapshotPoint TriggerLocation { get; }
+	public XmlSpineParser SpineParser { get; }
+	public CompletionTrigger Trigger { get; }
+	public SnapshotSpan ApplicableToSpan { get; }
+
+	internal XmlCompletionTrigger XmlTriggerKind { get; }
+	internal XmlTriggerReason XmlTriggerReason { get; }
+
+	public List<XObject> NodePath { get; private set; }
+
+	internal static XmlTriggerReason ConvertReason (CompletionTriggerReason reason, char typedChar)
+	{
+		switch (reason) {
+		case CompletionTriggerReason.Insertion:
+			if (typedChar != '\0')
+				return XmlTriggerReason.TypedChar;
+			break;
+		case CompletionTriggerReason.Backspace:
+			return XmlTriggerReason.Backspace;
+		case CompletionTriggerReason.Invoke:
+		case CompletionTriggerReason.InvokeAndCommitIfUnique:
+			return XmlTriggerReason.Invocation;
+		}
+		return XmlTriggerReason.Unknown;
+	}
+}


### PR DESCRIPTION
The context is created upfront and passed to all `GetCompletionsAsync` methods. Derived completion sources can subclass the context to attach additional information.

Completion source entrypoints now have exception logging.