### PR TITLE
Rework completion commit manager

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,9 @@ jobs:
 
     - uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: |
+          6.0.x
+          8.0.x
 
     - name: Restore
       run: dotnet restore MonoDevelop.Xml.sln

--- a/Editor/Completion/AbstractCompletionCommitManager.cs
+++ b/Editor/Completion/AbstractCompletionCommitManager.cs
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
+using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding;
+using Microsoft.VisualStudio.Threading;
+
+using MonoDevelop.Xml.Logging;
+
+namespace MonoDevelop.Xml.Editor.Completion;
+
+/// <summary>
+/// Abstract implementation of <see cref="IAsyncCompletionCommitManager"/> that codifies the pattern of handling sessions and items annotated
+/// with <see cref="TSessionTriggerKind"/> and <see cref="TItemKind"/> values on the session and item `Properties`, keyed by that type.
+/// </summary>
+/// <typeparam name="TSessionTriggerKind">Sessions annotated with this type will be handled.</typeparam>
+/// <typeparam name="TItemKind">Within sessions annotated by <see cref="TSessionTriggerKind"/>, items annotated this type will receive special handling.</typeparam>
+public abstract class AbstractCompletionCommitManager<TSessionTriggerKind, TItemKind> (
+		ILogger logger, JoinableTaskContext joinableTaskContext, IEditorCommandHandlerServiceFactory commandServiceFactory
+	) : IAsyncCompletionCommitManager
+{
+	readonly ILogger logger = logger;
+	readonly JoinableTaskContext joinableTaskContext = joinableTaskContext;
+	readonly IEditorCommandHandlerServiceFactory commandServiceFactory = commandServiceFactory;
+
+	public abstract IEnumerable<char> PotentialCommitCharacters { get; }
+
+	/// <summary>
+	/// For any session with a <see cref="TSessionTriggerKind"/> value, completion will be cancelled if this returns false for that value.
+	/// </summary>
+	protected abstract bool IsCommitCharForTriggerKind (TSessionTriggerKind trigger, IAsyncCompletionSession session, ITextSnapshot snapshot, char typedChar);
+
+	/// <summary>
+	/// When committing an item with a <see cref="TSessionTriggerKind"/> value on a session with a <see cref="TSessionTriggerKind"/> value,
+	/// this will be called to commit that item.
+	/// </summary>
+	protected abstract CommitResult TryCommitItemKind (TItemKind itemKind, IAsyncCompletionSession session, ITextBuffer buffer, CompletionItem item, char typedChar, CancellationToken token);
+
+	public bool ShouldCommitCompletion (IAsyncCompletionSession session, SnapshotPoint location, char typedChar, CancellationToken token)
+		=> logger.InvokeAndLogExceptions (() => ShouldCommitCompletionInternal (session, location, typedChar, token));
+
+	bool ShouldCommitCompletionInternal (IAsyncCompletionSession session, SnapshotPoint location, char typedChar, CancellationToken token)
+	{
+		// Only handle sessions that are annotated with TTriggerKind.
+		//
+		// Although we aren't told what exact item we might be committing yet, the trigger tells us enough
+		// about the kind of item to allow us to specialize the commit chars.
+		//
+		// NOTE: Returning false will not actually prevent the item from getting committed as another commit manager might handle it.
+		// We must also explicitly cancel the commit in TryCommit.
+		if (session.Properties.TryGetProperty (typeof (TSessionTriggerKind), out TSessionTriggerKind trigger)) {
+			return IsCommitCharForTriggerKind (trigger, session, location.Snapshot, typedChar);
+		};
+
+		return false;
+	}
+
+	protected static readonly CommitResult CommitSwallowChar = new (true, CommitBehavior.SuppressFurtherTypeCharCommandHandlers);
+
+	protected static readonly CommitResult CommitCancel = new (true, CommitBehavior.CancelCommit);
+
+	public CommitResult TryCommit (IAsyncCompletionSession session, ITextBuffer buffer, CompletionItem item, char typedChar, CancellationToken token)
+		=> logger.InvokeAndLogExceptions (() => TryCommitInternal (session, buffer, item, typedChar, token));
+
+	CommitResult TryCommitInternal (IAsyncCompletionSession session, ITextBuffer buffer, CompletionItem item, char typedChar, CancellationToken token)
+	{
+		// This seems to get called if some other commit manager returned true from ShouldCommitCompletion even if we returned false.
+		// So, we have to check again whether this is a session that we participated in and whether it is a valid commit char.
+
+		// If we didn't participate in this session, let it fall through to other commit managers.
+		if (!session.Properties.TryGetProperty (typeof (TSessionTriggerKind), out TSessionTriggerKind trigger)) {
+			return CommitResult.Unhandled;
+		};
+
+		// If we did participate in the session and we don't consider the typed char to be a commit char for this trigger, cancel the commit.
+		// This prevents lower-priority generic commit manager from committing items with chars that could have matched our items.
+		if (typedChar != '\n' && typedChar != '\t') {
+			// per-item CommitCharacters overrides the default commit chars
+			if (item.CommitCharacters.IsDefaultOrEmpty) {
+				if (!IsCommitCharForTriggerKind (trigger, session, buffer.CurrentSnapshot, typedChar)) {
+					return CommitCancel;
+				}
+			} else if (item.CommitCharacters.Contains (typedChar)) {
+				return CommitCancel;
+			}
+		}
+
+		// If we didn't set an item kind, let it fall through to the default commit manager.
+		// Note that this means that if we add any items and don't set an item kind, they will be handled by the
+		// default manager, which may not commit on all of our commit chars.
+		if (!item.Properties.TryGetProperty (typeof (TItemKind), out TItemKind itemKind)) {
+			return CommitResult.Unhandled;
+		}
+
+		return TryCommitItemKind (itemKind, session, buffer, item, typedChar, token);
+	}
+
+	/// <summary>
+	/// Re-invoke completion after the commit is complete.
+	/// </summary>
+	protected void RetriggerCompletion (ITextView textView)
+	{
+		var task = Task.Run (async () => {
+			await joinableTaskContext.Factory.SwitchToMainThreadAsync ();
+			commandServiceFactory.GetService (textView).Execute ((v, b) => new Microsoft.VisualStudio.Text.Editor.Commanding.Commands.InvokeCompletionListCommandArgs (v, b), null);
+		});
+		task.LogTaskExceptionsAndForget (logger);
+	}
+
+	/// <summary>
+	/// Extend the span forwards to also include the specified character, if present.
+	/// </summary>
+	protected static void ExtendSpanToConsume (ref SnapshotSpan span, char charToConsume)
+	{
+		var snapshot = span.Snapshot;
+		if (snapshot.Length > span.End && snapshot[span.End] == charToConsume) {
+			span = new SnapshotSpan (snapshot, span.Start, span.Length + 1);
+		}
+	}
+
+	/// <summary>
+	/// Replace the span with the provided text and move the caret to the specified offset within that text.
+	/// </summary>
+	protected static void ReplaceSpanAndMoveCaret (IAsyncCompletionSession session, ITextBuffer buffer, SnapshotSpan spanToReplace, string insertionText, int caretOffsetWithinInsertedText)
+	{
+		ReplaceSpan (buffer, spanToReplace, insertionText);
+		session.TextView.Caret.MoveTo (new SnapshotPoint (buffer.CurrentSnapshot, spanToReplace.Start.Position + caretOffsetWithinInsertedText));
+	}
+
+	/// <summary>
+	/// Replace the span with the provided text.
+	/// </summary>
+	/// <param name="session"></param>
+	protected static void ReplaceSpan (ITextBuffer buffer, SnapshotSpan spanToReplace, string insertionText)
+	{
+		var bufferEdit = buffer.CreateEdit ();
+		bufferEdit.Replace (spanToReplace, insertionText);
+		bufferEdit.Apply ();
+	}
+
+	/// <summary>
+	/// Replace the session's ApplicableToSpan with the provided text.
+	/// </summary>
+	protected static void ReplaceApplicableToSpan (IAsyncCompletionSession session, ITextBuffer buffer, string text)
+	{
+		var span = session.ApplicableToSpan.GetSpan (buffer.CurrentSnapshot);
+		ReplaceSpan (buffer, span, text);
+	}
+}

--- a/Editor/Completion/XmlCompletionCommitManager.cs
+++ b/Editor/Completion/XmlCompletionCommitManager.cs
@@ -1,281 +1,202 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
 using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding;
+using Microsoft.VisualStudio.Threading;
 
 using MonoDevelop.Xml.Dom;
 using MonoDevelop.Xml.Editor.Options;
-using MonoDevelop.Xml.Logging;
 
-namespace MonoDevelop.Xml.Editor.Completion
+namespace MonoDevelop.Xml.Editor.Completion;
+
+class XmlCompletionCommitManager (ILogger logger, JoinableTaskContext joinableTaskContext, IEditorCommandHandlerServiceFactory commandServiceFactory)
+	: AbstractCompletionCommitManager<XmlCompletionTrigger, XmlCompletionItemKind>(logger, joinableTaskContext, commandServiceFactory)
 {
-	partial class XmlCompletionCommitManager : IAsyncCompletionCommitManager
+	public override IEnumerable<char> PotentialCommitCharacters => allCommitChars;
+
+	static readonly char[] allCommitChars = { '>', '/', '=', ' ', ';', '"', '\'' };
+	static readonly char[] attributeCommitChars = { '=', ' ', '"', '\'' };
+	static readonly char[] tagCommitChars = { '>', '/', ' ' };
+	static readonly char[] entityCommitChars = { ';' };
+	static readonly char[] attributeValueCommitChars = { '"', '\'' };
+
+	static char[] GetCommitChars (XmlCompletionTrigger trigger)
+		=> trigger switch {
+			XmlCompletionTrigger.Tag or
+			XmlCompletionTrigger.ElementName or
+			XmlCompletionTrigger.ElementValue or
+			XmlCompletionTrigger.DocType => tagCommitChars,
+			XmlCompletionTrigger.AttributeName => attributeCommitChars,
+			XmlCompletionTrigger.AttributeValue => attributeValueCommitChars,
+			XmlCompletionTrigger.Entity => entityCommitChars,
+			XmlCompletionTrigger.DeclarationOrCDataOrComment => allCommitChars,
+			_ => throw new ArgumentOutOfRangeException ($"Unhandled value XmlCompletionTrigger.{trigger}")
+		};
+
+	protected override bool IsCommitCharForTriggerKind (XmlCompletionTrigger trigger, IAsyncCompletionSession session, ITextSnapshot snapshot, char typedChar)
 	{
-		static readonly char[] allCommitChars = { '>', '/', '=', ' ', ';', '"', '\'' };
-		static readonly char[] attributeCommitChars = { '=', ' ', '"', '\'' };
-		static readonly char[] tagCommitChars = { '>', '/', ' ' };
-		static readonly char[] entityCommitChars = { ';' };
-		static readonly char[] attributeValueCommitChars = { '"', '\'' };
-
-		readonly XmlCompletionCommitManagerProvider provider;
-		readonly ILogger logger;
-
-		public XmlCompletionCommitManager (XmlCompletionCommitManagerProvider provider, ILogger logger)
-		{
-			this.provider = provider;
-			this.logger = logger;
-		}
-
-		public IEnumerable<char> PotentialCommitCharacters => allCommitChars;
-
-		public bool ShouldCommitCompletion (IAsyncCompletionSession session, SnapshotPoint location, char typedChar, CancellationToken token)
-			=> logger.InvokeAndLogExceptions (() => ShouldCommitCompletionInternal (session, location, typedChar, token));
-
-		bool ShouldCommitCompletionInternal (IAsyncCompletionSession session, SnapshotPoint location, char typedChar, CancellationToken token)
-		{
-			if (Array.IndexOf (allCommitChars, typedChar) < 0) {
-				return false;
-			}
-
-			// only handle sessions that XML completion participated in
-			// although we aren't told what exact item we might be committing yet, the trigger tells us enough
-			// about the kind of item to allow us to specialize the commit chars
-			if (!session.Properties.TryGetProperty (typeof (XmlCompletionTrigger), out XmlCompletionTrigger kind)) {
-				return false;
-			};
-
-			switch (kind) {
-			case XmlCompletionTrigger.Tag:
-			case XmlCompletionTrigger.ElementName:
-			case XmlCompletionTrigger.ElementValue:
-				// allow using / as a commit char for elements as self-closing elements, but special case disallowing it
-				// in the cases where that could conflict with typing the / at the start of a closing tag
-				if (typedChar == '/') {
-					var span = session.ApplicableToSpan.GetSpan (location.Snapshot);
-					if (span.Length == (kind == XmlCompletionTrigger.ElementName ? 0 : 1)) {
-						return false;
-					}
-				}
-				return Array.IndexOf (tagCommitChars, typedChar) > -1;
-
-			case XmlCompletionTrigger.AttributeName:
-				return Array.IndexOf (attributeCommitChars, typedChar) > -1;
-
-			case XmlCompletionTrigger.AttributeValue:
-				return Array.IndexOf (attributeValueCommitChars, typedChar) > -1;
-
-			case XmlCompletionTrigger.DocType:
-				return Array.IndexOf (tagCommitChars, typedChar) > -1;
-
-			case XmlCompletionTrigger.Entity:
-				return Array.IndexOf (entityCommitChars, typedChar) > -1;
-			}
-
-			return false;
-		}
-
-		static readonly CommitResult CommitSwallowChar = new (true, CommitBehavior.SuppressFurtherTypeCharCommandHandlers);
-
-		static readonly CommitResult CommitCancel = new (true, CommitBehavior.CancelCommit);
-
-		public CommitResult TryCommit (IAsyncCompletionSession session, ITextBuffer buffer, CompletionItem item, char typedChar, CancellationToken token)
-			=> logger.InvokeAndLogExceptions (() => TryCommitInternal (session, buffer, item, typedChar, token));
-
-		public CommitResult TryCommitInternal (IAsyncCompletionSession session, ITextBuffer buffer, CompletionItem item, char typedChar, CancellationToken token)
-		{
-			if (!item.TryGetKind (out var kind)) {
-				return CommitResult.Unhandled;
-			}
-
-			// per-item CommitCharacters overrides the default commit chars
-			if (!item.CommitCharacters.IsDefaultOrEmpty) {
-				if (item.CommitCharacters.Contains (typedChar)) {
-					return CommitCancel;
+		switch (trigger) {
+		case XmlCompletionTrigger.ElementValue:
+			// allow using / as a commit char for elements as self-closing elements, but special case disallowing it
+			// in the cases where that could conflict with typing the / at the start of a closing tag
+			if (typedChar == '/') {
+				var span = session.ApplicableToSpan.GetSpan (snapshot);
+				if (span.Length == (trigger == XmlCompletionTrigger.ElementName ? 0 : 1)) {
+					return false;
 				}
 			}
+			goto default;
+		default:
+			var commitChars = GetCommitChars (trigger);
+			return Array.IndexOf (commitChars, typedChar) > -1;
+		}
+	}
 
-			var span = session.ApplicableToSpan.GetSpan (buffer.CurrentSnapshot);
-			bool wasTypedInFull = span.Length == item.InsertText.Length;
+	protected override CommitResult TryCommitItemKind (XmlCompletionItemKind itemKind, IAsyncCompletionSession session, ITextBuffer buffer, CompletionItem item, char typedChar, CancellationToken token)
+	{
+		var span = session.ApplicableToSpan.GetSpan (buffer.CurrentSnapshot);
+		bool wasTypedInFull = span.Length == item.InsertText.Length;
 
-			switch (kind) {
-			case XmlCompletionItemKind.SelfClosingElement: {
-					//comitting self-closing element with > makes it non-self-closing
-					if (typedChar == '>') {
-						goto case XmlCompletionItemKind.Element;
-					}
+		switch (itemKind) {
+		case XmlCompletionItemKind.SelfClosingElement: {
+				//comitting self-closing element with > makes it non-self-closing
+				if (typedChar == '>') {
+					goto case XmlCompletionItemKind.Element;
+				}
 
-					ConsumeTrailingChar (ref span, '>');
+				ExtendSpanToConsume (ref span, '>');
 
-					string insertionText = $"{item.InsertText}/>";
-					Insert (session, buffer, insertionText, span);
-					SetCaretSpanOffset (item.InsertText.Length);
+				string insertionText = $"{item.InsertText}/>";
+				ReplaceSpanAndMoveCaret (session, buffer, span, insertionText, item.InsertText.Length);
 
-					// don't insert double /
-					if (typedChar == '/' && !wasTypedInFull) {
-						return CommitSwallowChar;
-					}
+				// don't insert double /
+				if (typedChar == '/' && !wasTypedInFull) {
+					return CommitSwallowChar;
+				}
 
+				return CommitResult.Handled;
+			}
+		case XmlCompletionItemKind.Attribute: {
+				// simple handling if it might interfere with typing or auto attributes are disabled
+				if (typedChar == '=' || typedChar == ' ' || !session.TextView.Options.GetAutoInsertAttributeValue ()) {
+					ReplaceSpan (buffer, span, item.InsertText);
 					return CommitResult.Handled;
 				}
-			case XmlCompletionItemKind.Attribute: {
-					// simple handling if it might interfere with typing or auto attributes are disabled
-					if (typedChar == '=' || typedChar == ' ' || !session.TextView.Options.GetAutoInsertAttributeValue ()) {
-						Insert (session, buffer, item.InsertText, span);
-						return CommitResult.Handled;
-					}
 
-					//FIXME get this from options
-					char quoteChar = typedChar == '\'' ? '\'' : '"';
+				//FIXME get this from options
+				char quoteChar = typedChar == '\'' ? '\'' : '"';
 
-					// previously this code tried to insert the = and feed the " through the brace manager to get a
-					// brace completion session, but that didn't 't work when inserting attributes into existing elements
-					// as VS brace completion only works at the end of the line. now we have a XmlBraceCompletionCommandHandler
-					// that implements custom overtype behaviors, and we can just insert the entire =""
-					Insert (session, buffer, $"{item.InsertText}={quoteChar}{quoteChar}", span);
-					SetCaretSpanOffset (item.InsertText.Length + 2);
-					//explicitly trigger completion for the attribute value
-					RetriggerCompletion (session.TextView);
-					//if the user typed the quote char we're inserting, swallow it so they don't end up mismatched
-					return typedChar == quoteChar? CommitSwallowChar : CommitResult.Handled;
-				}
-			case XmlCompletionItemKind.Element:
-			case XmlCompletionItemKind.AttributeValue: {
-					Insert (session, buffer, item.InsertText, span);
-					return CommitResult.Handled;
-				}
-			case XmlCompletionItemKind.MultipleClosingTags:
-			case XmlCompletionItemKind.ClosingTag: {
-					InsertClosingTags (session, buffer, item);
-					return CommitResult.Handled;
-				}
-			case XmlCompletionItemKind.Comment: {
-					// this should probably be handled with brace matching and a separate undo step
-					// but this is better than nothing
-					ConsumeTrailingChar (ref span, '>');
-					Insert (session, buffer, item.InsertText + "-->", span);
-					SetCaretSpanOffset (item.InsertText.Length);
-					return CommitResult.Handled;
-				}
-			case XmlCompletionItemKind.CData: {
-					// this should probably be handled with brace matching and a separate undo step
-					// but this is better than nothing
-					ConsumeTrailingChar (ref span, ']');
-					ConsumeTrailingChar (ref span, ']');
-					ConsumeTrailingChar (ref span, '>');
-					Insert (session, buffer, item.InsertText + "]]>", span);
-					SetCaretSpanOffset (item.InsertText.Length);
-					return CommitResult.Handled;
-				}
+				// previously this code tried to insert the = and feed the " through the brace manager to get a
+				// brace completion session, but that didn't 't work when inserting attributes into existing elements
+				// as VS brace completion only works at the end of the line. now we have a XmlBraceCompletionCommandHandler
+				// that implements custom overtype behaviors, and we can just insert the entire =""
+				ReplaceSpanAndMoveCaret (session, buffer, span, $"{item.InsertText}={quoteChar}{quoteChar}", item.InsertText.Length + 2);
+				//explicitly trigger completion for the attribute value
+				RetriggerCompletion (session.TextView);
+				//if the user typed the quote char we're inserting, swallow it so they don't end up mismatched
+				return typedChar == quoteChar? CommitSwallowChar : CommitResult.Handled;
 			}
-
-			LogDidNotHandleCompletionKind (logger, kind);
-
-			return CommitResult.Unhandled;
-
-			void SetCaretSpanOffset (int spanOffset)
-				=> session.TextView.Caret.MoveTo (
-					new SnapshotPoint (buffer.CurrentSnapshot, span.Start.Position + spanOffset));
+		case XmlCompletionItemKind.Element:
+		case XmlCompletionItemKind.AttributeValue: {
+				ReplaceSpan (buffer, span, item.InsertText);
+				return CommitResult.Handled;
+			}
+		case XmlCompletionItemKind.MultipleClosingTags:
+		case XmlCompletionItemKind.ClosingTag: {
+				InsertClosingTags (session, buffer, item);
+				return CommitResult.Handled;
+			}
+		case XmlCompletionItemKind.Comment: {
+				// this should probably be handled with brace matching and a separate undo step
+				// but this is better than nothing
+				ExtendSpanToConsume (ref span, '>');
+				ReplaceSpanAndMoveCaret (session, buffer, span, item.InsertText + "-->", item.InsertText.Length);
+				return CommitResult.Handled;
+			}
+		case XmlCompletionItemKind.CData: {
+				// this should probably be handled with brace matching and a separate undo step
+				// but this is better than nothing
+				ExtendSpanToConsume (ref span, ']');
+				ExtendSpanToConsume (ref span, ']');
+				ExtendSpanToConsume (ref span, '>');
+				ReplaceSpanAndMoveCaret (session, buffer, span, item.InsertText + "]]>", item.InsertText.Length);
+				return CommitResult.Handled;
+			}
+		default:
+			throw new InvalidOperationException ($"Unhandled XmlCompletionItemKind value '{itemKind}'");
 		}
+	}
 
-		[LoggerMessage (Level = LogLevel.Warning, Message = "Did not handle completion kind {kind}")]
-		static partial void LogDidNotHandleCompletionKind (ILogger logger, XmlCompletionItemKind kind);
+	static void InsertClosingTags (IAsyncCompletionSession session, ITextBuffer buffer, CompletionItem item)
+	{
+		// completion may or may not include it depending how it was triggered
+		bool includesBracket = item.InsertText[0] == '<';
 
-		void RetriggerCompletion (ITextView textView)
-		{
-			var task = Task.Run (async () => {
-				await provider.JoinableTaskContext.Factory.SwitchToMainThreadAsync ();
-				provider.CommandServiceFactory.GetService (textView).Execute ((v, b) => new Microsoft.VisualStudio.Text.Editor.Commanding.Commands.InvokeCompletionListCommandArgs (v, b), null);
-			});
-			task.LogTaskExceptionsAndForget (logger);
-		}
-
-		static void ConsumeTrailingChar (ref SnapshotSpan span, char charToConsume)
-		{
-			var snapshot = span.Snapshot;
-			if (snapshot.Length > span.End && snapshot[span.End] == charToConsume) {
-				span = new SnapshotSpan (snapshot, span.Start, span.Length + 1);
+		var insertTillName = item.InsertText.Substring (includesBracket? 2 : 1);
+		var stack = item.Properties.GetProperty<List<XObject>> (typeof (List<XObject>));
+		var elements = new List<XElement> ();
+		for (int i = stack.Count - 1; i >= 0; i--) {
+			if (stack[i] is XElement el) {
+				elements.Add (el);
+				if (el.Name.FullName == insertTillName) {
+					break;
+				}
 			}
 		}
 
-		static void Insert (IAsyncCompletionSession session, ITextBuffer buffer, string text, SnapshotSpan span)
-		{
-			var bufferEdit = buffer.CreateEdit ();
-			bufferEdit.Replace (span, text);
-			bufferEdit.Apply ();
+		ITextSnapshot snapshot = buffer.CurrentSnapshot;
+		var span = session.ApplicableToSpan.GetSpan (snapshot);
+
+		// extend the span back to include the <, this logic assumes it's included
+		if (!includesBracket) {
+			span = new SnapshotSpan (span.Start - 1, span.Length + 1);
 		}
 
-		static void InsertClosingTags (IAsyncCompletionSession session, ITextBuffer buffer, CompletionItem item)
-		{
-			// completion may or may not include it depending how it was triggered
-			bool includesBracket = item.InsertText[0] == '<';
-
-			var insertTillName = item.InsertText.Substring (includesBracket? 2 : 1);
-			var stack = item.Properties.GetProperty<List<XObject>> (typeof (List<XObject>));
-			var elements = new List<XElement> ();
-			for (int i = stack.Count - 1; i >= 0; i--) {
-				if (stack[i] is XElement el) {
-					elements.Add (el);
-					if (el.Name.FullName == insertTillName) {
-						break;
-					}
-				}
+		// if this completion is the first thing on the current line, reindent the current line
+		var thisLine = snapshot.GetLineFromPosition (span.Start);
+		var thisLineFirstNonWhitespaceOffset = thisLine.GetFirstNonWhitespaceOffset ();
+		var replaceFirstIndent = thisLineFirstNonWhitespaceOffset.HasValue && thisLineFirstNonWhitespaceOffset + thisLine.Start == span.Start;
+		if (replaceFirstIndent) {
+			if (thisLine.LineNumber > 0) {
+				var prevLine = snapshot.GetLineFromLineNumber (thisLine.LineNumber - 1);
+				span = new SnapshotSpan (prevLine.End, span.End);
+			} else {
+				span = new SnapshotSpan (thisLine.Start, span.End);
 			}
-
-			ITextSnapshot snapshot = buffer.CurrentSnapshot;
-			var span = session.ApplicableToSpan.GetSpan (snapshot);
-
-			// extend the span back to include the <, this logic assumes it's included
-			if (!includesBracket) {
-				span = new SnapshotSpan (span.Start - 1, span.Length + 1);
-			}
-
-			// if this completion is the first thing on the current line, reindent the current line
-			var thisLine = snapshot.GetLineFromPosition (span.Start);
-			var thisLineFirstNonWhitespaceOffset = thisLine.GetFirstNonWhitespaceOffset ();
-			var replaceFirstIndent = thisLineFirstNonWhitespaceOffset.HasValue && thisLineFirstNonWhitespaceOffset + thisLine.Start == span.Start;
-			if (replaceFirstIndent) {
-				if (thisLine.LineNumber > 0) {
-					var prevLine = snapshot.GetLineFromLineNumber (thisLine.LineNumber - 1);
-					span = new SnapshotSpan (prevLine.End, span.End);
-				} else {
-					span = new SnapshotSpan (thisLine.Start, span.End);
-				}
-			}
-
-			var newLine = snapshot.GetText (thisLine.End, thisLine.EndIncludingLineBreak - thisLine.End);
-
-			var sb = new StringBuilder ();
-			foreach (var element in elements) {
-				var line = snapshot.GetLineFromPosition (element.Span.Start);
-				var firstNonWhitespaceOffset = line.GetFirstNonWhitespaceOffset ();
-				bool isFirstOnLine = firstNonWhitespaceOffset + line.Start == element.Span.Start;
-				// if the element we're closing started a line, put the closing tag on its own line with matching indentation
-				// unless it's on the current line
-				if (isFirstOnLine && line.LineNumber != thisLine.LineNumber) {
-					var whitespaceSpan = new Span (line.Start, firstNonWhitespaceOffset.Value);
-					var whitespace = snapshot.GetText (whitespaceSpan);
-					sb.Append (newLine);
-					sb.Append (whitespace);
-				}
-				sb.Append ($"</{element.Name.FullName}>");
-			}
-
-			ConsumeTrailingChar (ref span, '>');
-
-			var bufferEdit = buffer.CreateEdit ();
-			bufferEdit.Replace (span, sb.ToString ());
-			bufferEdit.Apply ();
 		}
+
+		var newLine = snapshot.GetText (thisLine.End, thisLine.EndIncludingLineBreak - thisLine.End);
+
+		var sb = new StringBuilder ();
+		foreach (var element in elements) {
+			var line = snapshot.GetLineFromPosition (element.Span.Start);
+			// if the element we're closing was on a different line, and started that line,
+			// then put the closing tag on a new line with indentation matching the opening tag
+			if (line.LineNumber != thisLine.LineNumber && line.GetFirstNonWhitespaceOffset () is int nonWhitespaceOffset && (nonWhitespaceOffset + line.Start == element.Span.Start)) {
+				var whitespaceSpan = new Span (line.Start, nonWhitespaceOffset);
+				var whitespace = snapshot.GetText (whitespaceSpan);
+				sb.Append (newLine);
+				sb.Append (whitespace);
+			}
+			sb.Append ($"</{element.Name.FullName}>");
+		}
+
+		ExtendSpanToConsume (ref span, '>');
+
+		var bufferEdit = buffer.CreateEdit ();
+		bufferEdit.Replace (span, sb.ToString ());
+		bufferEdit.Apply ();
 	}
 }


### PR DESCRIPTION
There was a lot of duplication between XmlCompletionCommitManager and MSBuildCompletionCommitManager, as they both followed a similar pattern.

Pull the shareable logic out into an abstract class as it's easy to get the subtleties wrong, and clean it up to be more consistent and more understandable.