### PR TITLE
Fix / committing <!-- in completion

### DIFF
--- a/Editor.Tests/Completion/CommitTests.cs
+++ b/Editor.Tests/Completion/CommitTests.cs
@@ -84,6 +84,34 @@ namespace MonoDevelop.Xml.Editor.Tests.Completion
 			);
 
 		[Test]
+		public Task ClosingTagSingleLineEof ()
+			=> this.TestCommands (
+@"<foo><bar>$",
+@"<foo><bar></bar>$",
+				(s) => {
+					s.InvokeCompletion ();
+					s.Type ("</b");
+					s.Enter ();
+				}
+			);
+
+		[Test]
+		public Task ClosingTagEof ()
+			=> this.TestCommands (
+@"<foo>
+  <bar>
+  $",
+@"<foo>
+  <bar>
+  </bar>$",
+				(s) => {
+					s.InvokeCompletion ();
+					s.Type ("</b");
+					s.Enter ();
+				}
+			);
+
+		[Test]
 		public Task MultipleClosingTags ()
 			=> this.TestCommands (
 @"<foo>

--- a/Editor/Completion/XmlCompletionCommitManager.cs
+++ b/Editor/Completion/XmlCompletionCommitManager.cs
@@ -49,7 +49,8 @@ class XmlCompletionCommitManager (ILogger logger, JoinableTaskContext joinableTa
 	protected override bool IsCommitCharForTriggerKind (XmlCompletionTrigger trigger, IAsyncCompletionSession session, ITextSnapshot snapshot, char typedChar)
 	{
 		switch (trigger) {
-		case XmlCompletionTrigger.ElementValue:
+		case XmlCompletionTrigger.Tag:
+		case XmlCompletionTrigger.ElementName:
 			// allow using / as a commit char for elements as self-closing elements, but special case disallowing it
 			// in the cases where that could conflict with typing the / at the start of a closing tag
 			if (typedChar == '/') {


### PR DESCRIPTION
This problem showed up in VS but not in the tests. Apparently the editor has changed its behavior since the editor version we use in the tests.