### PR TITLE
Fix AutoClosingTag for self-closing tags

### DIFF
--- a/Core/Parser/XmlTagState.cs
+++ b/Core/Parser/XmlTagState.cs
@@ -193,6 +193,12 @@ namespace MonoDevelop.Xml.Parser
 				xobject = el;
 			}
 
+			// if the element is incomplete due to an error, don't try to recover,
+			// instead let parent recreate state at start of tag
+			if (el != null && !el.IsComplete) {
+				return null;
+			}
+
 			if (el != null && position >= el.Span.Start && position < el.Span.End - 1) {
 				// recreating name builder and value builder state is a pain to get right
 				// for now, let parent recreate state at start of tag

--- a/Editor.Tests/Commands/AutoClosingTests.cs
+++ b/Editor.Tests/Commands/AutoClosingTests.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.Text.Editor;
+
+using MonoDevelop.Xml.Editor.Options;
+using MonoDevelop.Xml.Editor.Tests.Extensions;
+
+using NUnit.Framework;
+
+namespace MonoDevelop.Xml.Editor.Tests.Commands
+{
+	[TestFixture]
+	public class AutoClosingTests : XmlEditorTest
+	{
+
+		[TestCase (
+			"<r>\r\n <a e='v'|\r\n</r>",
+			"<r>\r\n <a e='v'>|</a>\r\n</r>"
+		)]
+		[TestCase (
+			"<r>\n <a e='v' /|\n</r>",
+			"<r>\n <a e='v' />|\n</r>"
+		)]
+		public Task TestComment (string sourceText, string expectedText, string typeChars = ">")
+		{
+			return this.TestCommands (
+				sourceText,
+				expectedText,
+				(s) => s.Type (typeChars),
+				caretMarkerChar: '|',
+				initialize: (ITextView tv) => {
+					tv.Options.SetOptionValue (XmlOptions.AutoInsertClosingTag, true);
+					return GetParser (tv.TextBuffer).GetOrProcessAsync (tv.TextBuffer.CurrentSnapshot, System.Threading.CancellationToken.None);
+				});
+		}
+	}
+}

--- a/Editor.Tests/Completion/CommitTests.cs
+++ b/Editor.Tests/Completion/CommitTests.cs
@@ -157,6 +157,7 @@ namespace MonoDevelop.Xml.Editor.Tests.Completion
 			var actions = typeChars.Split ('^').Select (t => { Action<IEditorCommandHandlerService> a = (s) => s.Type (t); return a; });
 			return this.TestCommands (before, after, actions, initialize: (ITextView tv) => {
 				tv.Options.SetOptionValue ("BraceCompletion/Enabled", true);
+				return Task.CompletedTask;
 			});
 		}
 

--- a/Editor.Tests/Extensions/EditorCommandExtensions.cs
+++ b/Editor.Tests/Extensions/EditorCommandExtensions.cs
@@ -23,7 +23,7 @@ namespace MonoDevelop.Xml.Editor.Tests.Extensions
 			string beforeDocumentText, string afterDocumentText,
 			Action<IEditorCommandHandlerService> command,
 			string filename = default, char caretMarkerChar = '$',
-			Action<ITextView> initialize = null,
+			Func<ITextView, Task> initialize = null,
 			CancellationToken cancellationToken = default)
 		{
 			return test.TestCommands (
@@ -41,7 +41,7 @@ namespace MonoDevelop.Xml.Editor.Tests.Extensions
 			string beforeDocumentText, string afterDocumentText,
 			IEnumerable<Action<IEditorCommandHandlerService>> commands,
 			string filename = default, char caretMarkerChar = '$',
-			Action<ITextView> initialize = null,
+			Func<ITextView, Task> initialize = null,
 			CancellationToken cancellationToken = default)
 		{
 			(beforeDocumentText, int beforeCaretOffset) = SelectionHelper.ExtractCaret (beforeDocumentText, caretMarkerChar);
@@ -61,7 +61,7 @@ namespace MonoDevelop.Xml.Editor.Tests.Extensions
 			string afterDocumentText, int afterCaretOffset,
 			IEnumerable<Action<IEditorCommandHandlerService>> commands,
 			string filename = default,
-			Action<ITextView> initialize = null,
+			Func<ITextView,Task> initialize = null,
 			CancellationToken cancellationToken = default)
 		{
 			await test.Catalog.JoinableTaskContext.Factory.SwitchToMainThreadAsync (cancellationToken);
@@ -69,7 +69,9 @@ namespace MonoDevelop.Xml.Editor.Tests.Extensions
 			var textView = test.CreateTextView (beforeDocumentText, filename);
 			textView.Caret.MoveTo (new SnapshotPoint (textView.TextBuffer.CurrentSnapshot, beforeCaretOffset));
 
-			initialize?.Invoke (textView);
+			if (initialize is not null) {
+				await initialize (textView);
+			}
 
 			var commandService = test.Catalog.CommandServiceFactory.GetService (textView);
 

--- a/Editor/Commands/AutoClosingTagCommandHandler.cs
+++ b/Editor/Commands/AutoClosingTagCommandHandler.cs
@@ -92,10 +92,7 @@ namespace MonoDevelop.Xml.Editor.Commands
 			// this is not as accurate as the tree parse we did above as it uses
 			// the last parse result, which might be a little stale
 			var lastParseResult = parser.LastOutput;
-			if (lastParseResult == null) {
-				return;
-			}
-			if (el.Parent != null) {
+			if (lastParseResult != null && el.Parent != null) {
 				if (lastParseResult.XDocument.FindAtOffset (el.Parent.Span.Start + 1) is XContainer parent) {
 					foreach (var n in parent.Nodes) {
 						if (n is XClosingTag) {


### PR DESCRIPTION
A race could cause a closing tag to be inserted if the tag was incomplete in the document used for spine recovery.

Should fix:

* #83 AutoClosingTag missing self-closed tags
* #25 AutoClosingTag doesn't work in large files
