### PR TITLE
Update to VS 17.5 APIs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,17 +1,25 @@
 <Project>
+  <PropertyGroup>
+    <!--
+    We cannot go higher than 17.5.
+    IConnectedSpan gained a new Disconnect() method in 17.6, which we cannot implement as it is internal.
+    -->
+    <VSEditorNugetVersion>17.5.279</VSEditorNugetVersion>
+  </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageVersion Include="Microsoft.VisualStudio.ImageCatalog" Version="17.2.32505.113" />
-    <PackageVersion Include="Microsoft.VisualStudio.Language.Intellisense" Version="17.2.3194" />
-    <PackageVersion Include="Microsoft.VisualStudio.Language.StandardClassification" Version="17.2.3194" />
-    <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="17.2.32" />
+    <PackageVersion Include="Microsoft.VisualStudio.ImageCatalog" Version="17.5.33428.366" />
+    <PackageVersion Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="17.5.33428.366" />
+    <PackageVersion Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(VSEditorNugetVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.Language.StandardClassification" Version="$(VSEditorNugetVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="17.5.22" />
     <PackageVersion Include="NUnit" Version="3.14.0" />
     <PackageVersion Include="NUnit.Analyzers" Version="3.10.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" PrivateAssets="all" />

--- a/Editor.Tests/Extensions/CompletionContextExtensions.cs
+++ b/Editor.Tests/Extensions/CompletionContextExtensions.cs
@@ -11,19 +11,19 @@ namespace MonoDevelop.Xml.Editor.Tests.Extensions
 	{
 		public static void AssertContains (this CompletionContext context, string name)
 		{
-			var item = context.Items.FirstOrDefault (i => i.DisplayText == name);
+			var item = context.ItemList.FirstOrDefault (i => i.DisplayText == name);
 			Assert.NotNull (item, "Completion result is missing item '{0}'", name);
 		}
 
 		public static void AssertNonEmpty (this CompletionContext context)
-			=> Assert.NotZero (context.Items.Length);
+			=> Assert.NotZero (context.ItemList.Count);
 
 		public static void AssertItemCount (this CompletionContext context, int expectedCount)
-			=> Assert.AreEqual (expectedCount, context.Items.Length);
+			=> Assert.AreEqual (expectedCount, context.ItemList.Count);
 
 		public static void AssertDoesNotContain (this CompletionContext context, string name)
 		{
-			var item = context.Items.FirstOrDefault (i => i.DisplayText == name);
+			var item = context.ItemList.FirstOrDefault (i => i.DisplayText == name);
 			Assert.IsNull (item, "Completion result has unexpected item '{0}'", name);
 		}
 	}

--- a/Editor.Tests/MonoDevelop.Xml.Editor.Tests.csproj
+++ b/Editor.Tests/MonoDevelop.Xml.Editor.Tests.csproj
@@ -30,5 +30,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" NoWarn="NU1701" />
     <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" NoWarn="NU1701" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" />
+    <PackageReference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" />
   </ItemGroup>
 </Project>

--- a/Editor.Tests/Schema/AbstractElementTestFixture.cs
+++ b/Editor.Tests/Schema/AbstractElementTestFixture.cs
@@ -42,7 +42,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task ItemsElementHasTwoChildElements()
 		{
 			await Init ();
-			Assert.AreEqual (2, itemsElementChildren.Items.Length, "Should be 2 child elements.");
+			Assert.AreEqual (2, itemsElementChildren.ItemList.Count, "Should be 2 child elements.");
 		}
 		
 		[Test]
@@ -70,7 +70,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task FileElementHasTwoChildElements()
 		{
 			await Init ();
-			Assert.AreEqual(2, fileElementChildren.Items.Length, "Should be 2 child elements.");
+			Assert.AreEqual(2, fileElementChildren.ItemList.Count, "Should be 2 child elements.");
 		}
 		
 		protected override string GetSchema()

--- a/Editor.Tests/Schema/AllElementTestFixture.cs
+++ b/Editor.Tests/Schema/AllElementTestFixture.cs
@@ -38,7 +38,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task PersonElementHasTwoChildElements()
 		{
 			await Init ();
-			Assert.AreEqual(2, personElementChildren.Items.Length, 
+			Assert.AreEqual(2, personElementChildren.ItemList.Count, 
 			                "Should be 2 child elements.");
 		}
 		
@@ -46,14 +46,14 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task FirstNameElementHasAttribute()
 		{
 			await Init ();
-			Assert.AreEqual(1, firstNameAttributes.Items.Length, "Should have one attribute.");
+			Assert.AreEqual(1, firstNameAttributes.ItemList.Count, "Should have one attribute.");
 		}
 		
 		[Test]
 		public async Task FirstNameElementHasChildren()
 		{
 			await Init ();
-			Assert.AreEqual(2, firstNameElementChildren.Items.Length, 
+			Assert.AreEqual(2, firstNameElementChildren.ItemList.Count, 
 			                "Should be 2 child elements.");
 		}
 		

--- a/Editor.Tests/Schema/AttributeAnnotationTestFixture.cs
+++ b/Editor.Tests/Schema/AttributeAnnotationTestFixture.cs
@@ -38,14 +38,14 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task FooAttributeDocumentation()
 		{
 			await Init ();
-			await AssertDescription("Documentation for foo attribute.", fooAttributeCompletionData.Items[0]);
+			await AssertDescription("Documentation for foo attribute.", fooAttributeCompletionData.ItemList[0]);
 		}
 		
 		[Test]
 		public async Task BarAttributeDocumentation()
 		{
 			await Init ();
-			await AssertDescription("Documentation for bar attribute.", barAttributeCompletionData.Items[0]);
+			await AssertDescription("Documentation for bar attribute.", barAttributeCompletionData.ItemList[0]);
 		}
 
 		protected override string GetSchema()

--- a/Editor.Tests/Schema/AttributeGroupRefTestFixture.cs
+++ b/Editor.Tests/Schema/AttributeGroupRefTestFixture.cs
@@ -27,7 +27,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task AttributeCount()
 		{
 			await Init ();
-			Assert.AreEqual(4, attributeCompletionData.Items.Length, "Should be 4 attributes.");
+			Assert.AreEqual(4, attributeCompletionData.ItemList.Count, "Should be 4 attributes.");
 		}
 		
 		[Test]

--- a/Editor.Tests/Schema/AttributeRefTestFixture.cs
+++ b/Editor.Tests/Schema/AttributeRefTestFixture.cs
@@ -27,7 +27,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task HtmlAttributeCount()
 		{
 			await Init ();
-			Assert.AreEqual(4, attributes.Items.Length, "Should be 4 attributes.");
+			Assert.AreEqual(4, attributes.ItemList.Count, "Should be 4 attributes.");
 		}
 		
 		[Test]

--- a/Editor.Tests/Schema/ChildElementAttributesTestFixture.cs
+++ b/Editor.Tests/Schema/ChildElementAttributesTestFixture.cs
@@ -29,7 +29,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task AttributeCount()
 		{
 			await Init ();
-			Assert.AreEqual(10, attributes.Items.Length, "Should be one attribute.");
+			Assert.AreEqual(10, attributes.ItemList.Count, "Should be one attribute.");
 		}
 		
 		[Test]

--- a/Editor.Tests/Schema/ChoiceTestFixture.cs
+++ b/Editor.Tests/Schema/ChoiceTestFixture.cs
@@ -32,7 +32,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 			XmlElementPath path = new XmlElementPath();
 			path.Elements.Add(new QualifiedName("note", "http://www.w3schools.com"));
 			path.Elements.Add(new QualifiedName("title", "http://www.w3schools.com"));
-			Assert.AreEqual(0, (await SchemaCompletionData.GetChildElementCompletionDataAsync (DummyCompletionSource.Instance, path, CancellationToken.None)).Items.Length, 
+			Assert.AreEqual(0, (await SchemaCompletionData.GetChildElementCompletionDataAsync (DummyCompletionSource.Instance, path, CancellationToken.None)).ItemList.Count, 
 			                "Should be no child elements.");
 		}
 		
@@ -43,7 +43,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 			XmlElementPath path = new XmlElementPath();
 			path.Elements.Add(new QualifiedName("note", "http://www.w3schools.com"));
 			path.Elements.Add(new QualifiedName("text", "http://www.w3schools.com"));
-			Assert.AreEqual(0, (await SchemaCompletionData.GetChildElementCompletionDataAsync (DummyCompletionSource.Instance, path, CancellationToken.None)).Items.Length, 
+			Assert.AreEqual(0, (await SchemaCompletionData.GetChildElementCompletionDataAsync (DummyCompletionSource.Instance, path, CancellationToken.None)).ItemList.Count, 
 			                "Should be no child elements.");
 		}		
 		
@@ -51,7 +51,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task NoteHasTwoChildElements()
 		{
 			await Init ();
-			Assert.AreEqual(2, noteChildElements.Items.Length, 
+			Assert.AreEqual(2, noteChildElements.ItemList.Count, 
 			                "Should be two child elements.");
 		}
 		

--- a/Editor.Tests/Schema/ComplexContentExtensionTestFixture.cs
+++ b/Editor.Tests/Schema/ComplexContentExtensionTestFixture.cs
@@ -34,7 +34,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 			path.Elements.Add(new QualifiedName("body", "http://www.w3schools.com")); 
 			path.Elements.Add(new QualifiedName("title", "http://www.w3schools.com")); 
 
-			Assert.AreEqual(0, (await SchemaCompletionData.GetChildElementCompletionDataAsync (DummyCompletionSource.Instance, path, CancellationToken.None)).Items.Length,
+			Assert.AreEqual(0, (await SchemaCompletionData.GetChildElementCompletionDataAsync (DummyCompletionSource.Instance, path, CancellationToken.None)).ItemList.Count,
 			                "Should be no child elements.");
 		}
 		
@@ -46,7 +46,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 			path.Elements.Add(new QualifiedName("body", "http://www.w3schools.com")); 
 			path.Elements.Add(new QualifiedName("text", "http://www.w3schools.com")); 
 
-			Assert.AreEqual(0, (await SchemaCompletionData.GetChildElementCompletionDataAsync (DummyCompletionSource.Instance, path, CancellationToken.None)).Items.Length,
+			Assert.AreEqual(0, (await SchemaCompletionData.GetChildElementCompletionDataAsync (DummyCompletionSource.Instance, path, CancellationToken.None)).ItemList.Count,
 			                "Should be no child elements.");
 		}		
 		
@@ -54,7 +54,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task BodyHasTwoChildElements()
 		{
 			await Init ();
-			Assert.AreEqual(2, bodyChildElements.Items.Length, 
+			Assert.AreEqual(2, bodyChildElements.ItemList.Count, 
 			                "Should be two child elements.");
 		}
 		
@@ -78,7 +78,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task BodyAttributeCount()
 		{
 			await Init ();
-			Assert.AreEqual(1, bodyAttributes.Items.Length, 
+			Assert.AreEqual(1, bodyAttributes.ItemList.Count, 
 			                "Should be one attribute.");
 		}
 		

--- a/Editor.Tests/Schema/DuplicateElementTestFixture.cs
+++ b/Editor.Tests/Schema/DuplicateElementTestFixture.cs
@@ -28,7 +28,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task HtmlHasTwoChildElements()
 		{
 			await Init ();
-			Assert.AreEqual(2, htmlChildElements.Items.Length, "Should be 2 child elements.");
+			Assert.AreEqual(2, htmlChildElements.ItemList.Count, "Should be 2 child elements.");
 		}
 		
 		[Test]

--- a/Editor.Tests/Schema/ElementAnnotationTestFixture.cs
+++ b/Editor.Tests/Schema/ElementAnnotationTestFixture.cs
@@ -33,14 +33,14 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task RootElementDocumentation()
 		{
 			await Init ();
-			await AssertDescription ("Documentation for foo element.", rootElementCompletionData.Items[0]);
+			await AssertDescription ("Documentation for foo element.", rootElementCompletionData.ItemList[0]);
 		}
 		
 		[Test]
 		public async Task FooChildElementDocumentation()
 		{
 			await Init ();
-			await AssertDescription ("Documentation for bar element.", fooChildElementCompletionData.Items[0]);
+			await AssertDescription ("Documentation for bar element.", fooChildElementCompletionData.ItemList[0]);
 		}
 		
 		protected override string GetSchema()

--- a/Editor.Tests/Schema/ElementWithAttributeSchemaTestFixture.cs
+++ b/Editor.Tests/Schema/ElementWithAttributeSchemaTestFixture.cs
@@ -23,14 +23,14 @@ namespace MonoDevelop.Xml.Tests.Schema
 			path.Elements.Add(new QualifiedName("note", "http://www.w3schools.com"));
 						
 			attributeCompletionData = await SchemaCompletionData.GetAttributeCompletionDataAsync (DummyCompletionSource.Instance, path, CancellationToken.None);
-			attributeName = attributeCompletionData.Items[0].DisplayText;
+			attributeName = attributeCompletionData.ItemList[0].DisplayText;
 		}
 
 		[Test]
 		public async Task AttributeCount()
 		{
 			await Init ();
-			Assert.AreEqual(1, attributeCompletionData.Items.Length, "Should be one attribute.");
+			Assert.AreEqual(1, attributeCompletionData.ItemList.Count, "Should be one attribute.");
 		}
 		
 		[Test]
@@ -48,7 +48,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 			path.Elements.Add(new QualifiedName("foobar", "http://www.w3schools.com"));
 			var attributes = await SchemaCompletionData.GetAttributeCompletionDataAsync (DummyCompletionSource.Instance, path, CancellationToken.None);
 			
-			Assert.AreEqual(0, attributes.Items.Length, "Should not find attributes for unknown element.");
+			Assert.AreEqual(0, attributes.ItemList.Count, "Should not find attributes for unknown element.");
 		}
 		
 		protected override string GetSchema()

--- a/Editor.Tests/Schema/EnumAttributeValueTestFixture.cs
+++ b/Editor.Tests/Schema/EnumAttributeValueTestFixture.cs
@@ -43,7 +43,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task IdAttributeValueCount()
 		{
 			await Init ();
-			Assert.AreEqual(2, attributeValues.Items.Length, "Expecting 2 attribute values.");
+			Assert.AreEqual (2, attributeValues.ItemList.Count, "Expecting 2 attribute values.");
 		}
 		
 		protected override string GetSchema()

--- a/Editor.Tests/Schema/ExtensionElementTestFixture.cs
+++ b/Editor.Tests/Schema/ExtensionElementTestFixture.cs
@@ -58,7 +58,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task SchemaHasSevenChildElements()
 		{
 			await Init ();
-			Assert.AreEqual(7, schemaChildElements.Items.Length, "Should be 7 child elements.");
+			Assert.AreEqual(7, schemaChildElements.ItemList.Count, "Should be 7 child elements.");
 		}
 		
 		[Test]
@@ -100,7 +100,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task AnnotationElementHasOneAttribute()
 		{
 			await Init ();
-			Assert.AreEqual(1, annotationAttributes.Items.Length, "Should be one attribute.");
+			Assert.AreEqual(1, annotationAttributes.ItemList.Count, "Should be one attribute.");
 		}
 		
 		[Test]
@@ -115,7 +115,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task AnnotationHasTwoChildElements()
 		{
 			await Init ();
-			Assert.AreEqual(2, annotationChildElements.Items.Length, 
+			Assert.AreEqual(2, annotationChildElements.ItemList.Count, 
 			                "Should be 2 child elements.");
 		}
 		
@@ -139,7 +139,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task IncludeElementHasOneAttribute()
 		{
 			await Init ();
-			Assert.AreEqual(1, includeAttributes.Items.Length, "Should be one attribute.");
+			Assert.AreEqual(1, includeAttributes.ItemList.Count, "Should be one attribute.");
 		}
 		
 		[Test]
@@ -154,7 +154,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task AppInfoElementHasOneAttribute()
 		{
 			await Init ();
-			Assert.AreEqual(1, appInfoAttributes.Items.Length, "Should be one attribute.");
+			Assert.AreEqual(1, appInfoAttributes.ItemList.Count, "Should be one attribute.");
 		}
 		
 		[Test]

--- a/Editor.Tests/Schema/GroupRefCompositorTestFixture.cs
+++ b/Editor.Tests/Schema/GroupRefCompositorTestFixture.cs
@@ -38,7 +38,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task RootHasTwoChildElements()
 		{
 			await Init ();
-			Assert.AreEqual(2, rootChildElements.Items.Length, "Should be two child elements.");
+			Assert.AreEqual(2, rootChildElements.ItemList.Count, "Should be two child elements.");
 		}
 		
 		[Test]

--- a/Editor.Tests/Schema/GroupRefTestFixture.cs
+++ b/Editor.Tests/Schema/GroupRefTestFixture.cs
@@ -35,7 +35,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task BodyHasFourChildElements()
 		{
 			await Init ();
-			Assert.AreEqual(4, childElements.Items.Length, 
+			Assert.AreEqual(4, childElements.ItemList.Count, 
 			                "Should be 4 child elements.");
 		}
 		

--- a/Editor.Tests/Schema/MissingSchemaElementTestFixture.cs
+++ b/Editor.Tests/Schema/MissingSchemaElementTestFixture.cs
@@ -27,7 +27,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task BarHasOneAttribute()
 		{
 			await Init ();
-			Assert.AreEqual(1, barElementAttributes.Items.Length, "Should have 1 attribute.");
+			Assert.AreEqual(1, barElementAttributes.ItemList.Count, "Should have 1 attribute.");
 		}
 		
 		protected override string GetSchema()

--- a/Editor.Tests/Schema/NamespaceCompletionTestFixture.cs
+++ b/Editor.Tests/Schema/NamespaceCompletionTestFixture.cs
@@ -42,7 +42,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		[Test]
 		public void NamespaceCount()
 		{
-			Assert.AreEqual(2, namespaceCompletionData.Items.Length, "Should be 2 namespaces.");
+			Assert.AreEqual(2, namespaceCompletionData.ItemList.Count, "Should be 2 namespaces.");
 		}
 		
 		[Test]

--- a/Editor.Tests/Schema/NestedAttributeGroupRefTestFixture.cs
+++ b/Editor.Tests/Schema/NestedAttributeGroupRefTestFixture.cs
@@ -27,7 +27,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task AttributeCount()
 		{
 			await Init ();
-			Assert.AreEqual(7, attributeCompletionData.Items.Length, "Should be 7 attributes.");
+			Assert.AreEqual(7, attributeCompletionData.ItemList.Count, "Should be 7 attributes.");
 		}
 		
 		[Test]

--- a/Editor.Tests/Schema/NestedChoiceTestFixture.cs
+++ b/Editor.Tests/Schema/NestedChoiceTestFixture.cs
@@ -36,7 +36,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task TitleHasTwoChildElements()
 		{
 			await Init ();
-			Assert.AreEqual(2, titleChildElements.Items.Length, "Should be 2 child elements.");
+			Assert.AreEqual(2, titleChildElements.ItemList.Count, "Should be 2 child elements.");
 		}
 		
 		[Test]
@@ -46,7 +46,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 			XmlElementPath path = new XmlElementPath();
 			path.Elements.Add(new QualifiedName("note", "http://www.w3schools.com"));
 			path.Elements.Add(new QualifiedName("text", "http://www.w3schools.com"));
-			Assert.AreEqual(0, (await SchemaCompletionData.GetChildElementCompletionDataAsync (DummyCompletionSource.Instance, path, CancellationToken.None)).Items.Length, 
+			Assert.AreEqual(0, (await SchemaCompletionData.GetChildElementCompletionDataAsync (DummyCompletionSource.Instance, path, CancellationToken.None)).ItemList.Count, 
 			                "Should be no child elements.");
 		}		
 		
@@ -54,7 +54,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task NoteHasTwoChildElements()
 		{
 			await Init ();
-			Assert.AreEqual(2, noteChildElements.Items.Length, "Should be two child elements.");
+			Assert.AreEqual(2, noteChildElements.ItemList.Count, "Should be two child elements.");
 		}
 		
 		[Test]

--- a/Editor.Tests/Schema/NestedElementSchemaTestFixture.cs
+++ b/Editor.Tests/Schema/NestedElementSchemaTestFixture.cs
@@ -27,7 +27,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task NoteHasOneChildElementCompletionDataItem()
 		{
 			await Init ();
-			Assert.AreEqual(1, elementData.Items.Length, "Should be one child element completion data item.");
+			Assert.AreEqual(1, elementData.ItemList.Count, "Should be one child element completion data item.");
 		}
 		
 		[Test]

--- a/Editor.Tests/Schema/NestedSequenceTestFixture.cs
+++ b/Editor.Tests/Schema/NestedSequenceTestFixture.cs
@@ -32,7 +32,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 			XmlElementPath path = new XmlElementPath();
 			path.Elements.Add(new QualifiedName("note", "http://www.w3schools.com"));
 			path.Elements.Add(new QualifiedName("title", "http://www.w3schools.com"));
-			Assert.AreEqual(0, (await SchemaCompletionData.GetChildElementCompletionDataAsync (DummyCompletionSource.Instance, path, CancellationToken.None)).Items.Length,
+			Assert.AreEqual(0, (await SchemaCompletionData.GetChildElementCompletionDataAsync (DummyCompletionSource.Instance, path, CancellationToken.None)).ItemList.Count,
 			                "Should be no child elements.");
 		}
 		
@@ -43,7 +43,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 			XmlElementPath path = new XmlElementPath();
 			path.Elements.Add(new QualifiedName("note", "http://www.w3schools.com"));
 			path.Elements.Add(new QualifiedName("text", "http://www.w3schools.com"));
-			Assert.AreEqual(0, (await SchemaCompletionData.GetChildElementCompletionDataAsync (DummyCompletionSource.Instance, path, CancellationToken.None)).Items.Length, 
+			Assert.AreEqual(0, (await SchemaCompletionData.GetChildElementCompletionDataAsync (DummyCompletionSource.Instance, path, CancellationToken.None)).ItemList.Count, 
 			                "Should be no child elements.");
 		}		
 		
@@ -51,7 +51,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task NoteHasTwoChildElements()
 		{
 			await Init ();
-			Assert.AreEqual(2, noteChildElements.Items.Length, "Should be two child elements.");
+			Assert.AreEqual(2, noteChildElements.ItemList.Count, "Should be two child elements.");
 		}
 		
 		[Test]

--- a/Editor.Tests/Schema/ReferencedElementsTestFixture.cs
+++ b/Editor.Tests/Schema/ReferencedElementsTestFixture.cs
@@ -41,7 +41,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task OneShipOrderAttribute()
 		{
 			await Init ();
-			Assert.AreEqual(1, shipOrderAttributes.Items.Length, "Should only have one shiporder attribute.");
+			Assert.AreEqual(1, shipOrderAttributes.ItemList.Count, "Should only have one shiporder attribute.");
 		}		
 		
 		[Test]
@@ -56,7 +56,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task OneShipToAttribute()
 		{
 			await Init ();
-			Assert.AreEqual(1, shipToAttributes.Items.Length, "Should only have one shipto attribute.");
+			Assert.AreEqual(1, shipToAttributes.ItemList.Count, "Should only have one shipto attribute.");
 		}
 		
 		[Test]
@@ -71,7 +71,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task ShipOrderChildElementsCount()
 		{
 			await Init ();
-			Assert.AreEqual(1, (await SchemaCompletionData.GetChildElementCompletionDataAsync (DummyCompletionSource.Instance, shipOrderPath, CancellationToken.None)).Items.Length, 
+			Assert.AreEqual(1, (await SchemaCompletionData.GetChildElementCompletionDataAsync (DummyCompletionSource.Instance, shipOrderPath, CancellationToken.None)).ItemList.Count, 
 			                "Should be one child element.");
 		}
 		
@@ -88,7 +88,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task ShipToChildElementsCount()
 		{
 			await Init ();
-			Assert.AreEqual(2, (await SchemaCompletionData.GetChildElementCompletionDataAsync (DummyCompletionSource.Instance, shipToPath, CancellationToken.None)).Items.Length, 
+			Assert.AreEqual(2, (await SchemaCompletionData.GetChildElementCompletionDataAsync (DummyCompletionSource.Instance, shipToPath, CancellationToken.None)).ItemList.Count, 
 			                "Should be 2 child elements.");
 		}		
 		

--- a/Editor.Tests/Schema/SchemaTestFixtureBase.cs
+++ b/Editor.Tests/Schema/SchemaTestFixtureBase.cs
@@ -52,7 +52,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		{
 			bool Contains = false;
 			
-			foreach (var data in items.Items) {
+			foreach (var data in items.ItemList) {
 				if (data.DisplayText == name) {
 					Contains = true;
 					break;
@@ -70,7 +70,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		{
 			bool Contains = false;
 			
-			foreach (var data in items.Items) {
+			foreach (var data in items.ItemList) {
 				if (data.DisplayText == name) {
 					var descEl = await data.GetDocumentationAsync (null, default) as ClassifiedTextElement;
 					if (descEl != null && descEl.Runs.FirstOrDefault()?.Text == description) {
@@ -91,7 +91,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		{
 			int count = 0;
 			
-			foreach (var data in items.Items) {
+			foreach (var data in items.ItemList) {
 				if (data.DisplayText == name) {
 					++count;
 				}

--- a/Editor.Tests/Schema/SequencedChoiceTestFixture.cs
+++ b/Editor.Tests/Schema/SequencedChoiceTestFixture.cs
@@ -34,7 +34,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 			path.Elements.Add(new QualifiedName("note", "http://www.w3schools.com"));
 			path.Elements.Add(new QualifiedName("title", "http://www.w3schools.com"));
 			
-			Assert.AreEqual(0, (await SchemaCompletionData.GetChildElementCompletionDataAsync (DummyCompletionSource.Instance, path, CancellationToken.None)).Items.Length, 
+			Assert.AreEqual(0, (await SchemaCompletionData.GetChildElementCompletionDataAsync (DummyCompletionSource.Instance, path, CancellationToken.None)).ItemList.Count, 
 			                "Should be no child elements.");
 		}
 		
@@ -46,7 +46,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 			path.Elements.Add(new QualifiedName("note", "http://www.w3schools.com"));
 			path.Elements.Add(new QualifiedName("title", "http://www.w3schools.com"));
 
-			Assert.AreEqual(0, (await SchemaCompletionData.GetChildElementCompletionDataAsync (DummyCompletionSource.Instance, path, CancellationToken.None)).Items.Length,
+			Assert.AreEqual(0, (await SchemaCompletionData.GetChildElementCompletionDataAsync (DummyCompletionSource.Instance, path, CancellationToken.None)).ItemList.Count,
 			                "Should be no child elements.");
 		}		
 		
@@ -54,7 +54,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task NoteHasTwoChildElements()
 		{
 			await Init ();
-			Assert.AreEqual(2, noteChildElements.Items.Length, 
+			Assert.AreEqual(2, noteChildElements.ItemList.Count, 
 			                "Should be two child elements.");
 		}
 		

--- a/Editor.Tests/Schema/SingleElementSchemaTestFixture.cs
+++ b/Editor.Tests/Schema/SingleElementSchemaTestFixture.cs
@@ -42,14 +42,14 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task NoteElementHasNoAttributes()
 		{
 			await Init ();
-			Assert.AreEqual(0, attributeCompletionData.Items.Length, "Not expecting any attributes.");
+			Assert.AreEqual(0, attributeCompletionData.ItemList.Count, "Not expecting any attributes.");
 		}
 		
 		[Test]
 		public async Task NoteElementHasNoChildElements()
 		{
 			await Init ();
-			Assert.AreEqual(0, childElementCompletionData.Items.Length, "Not expecting any child elements.");
+			Assert.AreEqual(0, childElementCompletionData.ItemList.Count, "Not expecting any child elements.");
 		}
 		
 		protected override string GetSchema()

--- a/Editor.Tests/Schema/TwoElementSchemaTestFixture.cs
+++ b/Editor.Tests/Schema/TwoElementSchemaTestFixture.cs
@@ -33,7 +33,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		{
 			var attributesCompletionData = await SchemaCompletionData.GetAttributeCompletionDataAsync (DummyCompletionSource.Instance, textElementPath, CancellationToken.None);
 			
-			Assert.AreEqual (1, attributesCompletionData.Items.Length, "Should have 1 text attribute.");
+			Assert.AreEqual (1, attributesCompletionData.ItemList.Count, "Should have 1 text attribute.");
 		}
 		
 		[Test]
@@ -48,7 +48,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		{
 			var childElementCompletionData = await SchemaCompletionData.GetChildElementCompletionDataAsync (DummyCompletionSource.Instance, noteElementPath, CancellationToken.None);
 			
-			Assert.AreEqual(1, childElementCompletionData.Items.Length, "Should be one child.");
+			Assert.AreEqual(1, childElementCompletionData.ItemList.Count, "Should be one child.");
 		}
 		
 		[Test]
@@ -56,7 +56,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		{	
 			var attributeCompletionData = await SchemaCompletionData.GetAttributeCompletionDataAsync (DummyCompletionSource.Instance, noteElementPath, CancellationToken.None);
 			
-			Assert.AreEqual(0, attributeCompletionData.Items.Length, "Should no attributes.");
+			Assert.AreEqual(0, attributeCompletionData.ItemList.Count, "Should no attributes.");
 		}
 
 		[Test]
@@ -64,7 +64,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		{
 			var elementCompletionData = await SchemaCompletionData.GetElementCompletionDataAsync (DummyCompletionSource.Instance, CancellationToken.None);
 			
-			Assert.AreEqual(1, elementCompletionData.Items.Length, "Should be 1 root element.");
+			Assert.AreEqual(1, elementCompletionData.ItemList.Count, "Should be 1 root element.");
 		}
 		
 		[Test]

--- a/Editor.Tests/Schema/XhtmlStrictSchemaTestFixture.cs
+++ b/Editor.Tests/Schema/XhtmlStrictSchemaTestFixture.cs
@@ -49,7 +49,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task H1HasAttributes()
 		{
 			await Init ();
-			Assert.IsTrue(h1Attributes.Items.Length > 0, "Should have at least one attribute.");
+			Assert.IsTrue (h1Attributes.ItemList.Count > 0, "Should have at least one attribute.");
 		}
 	}
 }

--- a/Editor.Tests/Schema/XsdSchemaTestFixture.cs
+++ b/Editor.Tests/Schema/XsdSchemaTestFixture.cs
@@ -128,7 +128,7 @@ namespace MonoDevelop.Xml.Tests.Schema
 		public async Task ChoiceHasAttributes()
 		{
 			await Init ();
-			Assert.IsTrue(choiceAttributes.Items.Length > 0, "Should have at least one attribute.");
+			Assert.IsTrue(choiceAttributes.ItemList.Count > 0, "Should have at least one attribute.");
 		}
 		
 		[Test]

--- a/Editor/MonoDevelop.Xml.Editor.csproj
+++ b/Editor/MonoDevelop.Xml.Editor.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" ExcludeAssets="runtime" NoWarn="NU1701" />
     <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" ExcludeAssets="runtime" NoWarn="NU1701" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We cannot go higher, as IConnectedSpan gained a new Disconnect() method in 17.6, which MiniEditor cannot implement as it is internal.