### PR TITLE
Remove MiniEditor dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,10 +6,14 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os:
+          - name: windows-latest
+            sln: MonoDevelop.Xml.sln
+          - name: ubuntu-latest
+            sln: NoVSEditor.slnf
         config: [ Debug ]
       fail-fast: false
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os.name }}
 
     steps:
     - uses: actions/checkout@v4
@@ -22,10 +26,10 @@ jobs:
           8.0.x
 
     - name: Restore
-      run: dotnet restore MonoDevelop.Xml.sln
+      run: dotnet restore ${{ matrix.os.sln }}
 
     - name: Build
-      run: dotnet build MonoDevelop.Xml.sln -c ${{ matrix.config }} --no-restore
+      run: dotnet build ${{ matrix.os.sln }} -c ${{ matrix.config }} --no-restore
 
     - name: Test
-      run: dotnet test -c ${{ matrix.config }} --no-build
+      run: dotnet test -c ${{ matrix.config }} --no-build ${{ matrix.os.sln }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,6 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0 # GitVersioning needs deep clone
-        submodules: recursive
 
     - uses: actions/setup-dotnet@v4
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 [Bb]in/
 packages/
 TestResults/
+artifacts/
 
 # globs
 Makefile.in

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "external/MiniEditor"]
-	path = external/MiniEditor
-	url = https://github.com/mhutch/MiniEditor

--- a/Core.Tests/MonoDevelop.Xml.Core.Tests.csproj
+++ b/Core.Tests/MonoDevelop.Xml.Core.Tests.csproj
@@ -31,5 +31,7 @@
     <PackageReference Include="NUnit.Analyzers" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <!-- upgrade vulnerable transitive dependencies -->
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 </Project>

--- a/Core.Tests/MonoDevelop.Xml.Core.Tests.csproj
+++ b/Core.Tests/MonoDevelop.Xml.Core.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
+    <!-- conditionally only build net48 on !windows so nunit doesn't try to run them -->
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">net48;net8.0</TargetFrameworks>
     <NUnitDisableSupportAssemblies>true</NUnitDisableSupportAssemblies>
     <RootNamespace>MonoDevelop.Xml.Tests</RootNamespace>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,5 +4,6 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)private.snk</AssemblyOriginatorKeyFile>
     <LangVersion>latest</LangVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <UseArtifactsOutput>True</UseArtifactsOutput>
   </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,28 +1,34 @@
 <Project>
-  <PropertyGroup>
-    <!--
-    We cannot go higher than 17.5.
-    IConnectedSpan gained a new Disconnect() method in 17.6, which we cannot implement as it is internal.
-    -->
-    <VSEditorNugetVersion>17.5.279</VSEditorNugetVersion>
-  </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageVersion Include="Microsoft.VisualStudio.ImageCatalog" Version="17.5.33428.366" />
-    <PackageVersion Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="17.5.33428.366" />
-    <PackageVersion Include="Microsoft.VisualStudio.Language.Intellisense" Version="$(VSEditorNugetVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.Language.StandardClassification" Version="$(VSEditorNugetVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="17.5.22" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageVersion Include="Microsoft.VisualStudio.ImageCatalog" Version="17.10.40170" />
+    <PackageVersion Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="17.10.40152" />
+    <PackageVersion Include="Microsoft.VisualStudio.Language.Intellisense" Version="17.10.191" />
+    <PackageVersion Include="Microsoft.VisualStudio.Language.StandardClassification" Version="17.10.191" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="17.10.48" />
+    <PackageVersion Include="Microsoft.VisualStudio.Editor" Version="17.10.191" />
     <PackageVersion Include="NUnit" Version="3.14.0" />
     <PackageVersion Include="NUnit.Analyzers" Version="3.10.0" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
+    <PackageVersion Include="Microsoft.VisualStudio.Utilities" Version="17.10.40170" />
+    <PackageVersion Include="Microsoft.VisualStudio.Interop" Version="17.10.40170" />
+    <PackageVersion Include="Microsoft.VisualStudio.GraphModel" Version="17.10.40170" />
+    <PackageVersion Include="Microsoft.VisualStudio.Imaging" Version="17.10.40170" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0" Version="17.10.40170" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.Framework" Version="17.10.40170" />
+    <PackageVersion Include="StreamJsonRpc" Version="2.19.27" />
+    <PackageVersion Include="Microsoft.VisualStudio.Platform.VSEditor" Version="17.10.191" />
+    <PackageVersion Include="Microsoft.VisualStudio.Text.Internal" Version="17.10.191" />
+    <PackageVersion Include="BasicUndo" Version="0.9.3" />
+    <PackageVersion Include="Microsoft.VisualStudio.Language" Version="17.10.191" />
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" PrivateAssets="all" />
-    <GlobalPackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All"/>
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.143" PrivateAssets="all" />
+    <GlobalPackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.4" PrivateAssets="All"/>
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,6 +26,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Text.Internal" Version="17.10.191" />
     <PackageVersion Include="BasicUndo" Version="0.9.3" />
     <PackageVersion Include="Microsoft.VisualStudio.Language" Version="17.10.191" />
+    <PackageVersion Include="Microsoft.IO.Redist" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.143" PrivateAssets="all" />

--- a/Editor.Tests/Commands/ExpandSelectionTests.cs
+++ b/Editor.Tests/Commands/ExpandSelectionTests.cs
@@ -63,6 +63,9 @@ a comment-->";
 
 		const string TextNode = "this is some text";
 
+		const string TextNodeWithWhitespace = @"	this is some text
+";
+
 		const string AttributesFoo = @"hello=""hi"" goodbye=""bye""";
 
 		const string AttributeHello = @"hello=""hi""";
@@ -91,6 +94,9 @@ a comment-->";
 
 		const string CommentBar = @"<!--another comment-->";
 
+		const string CommentBarWithWhitespace = @"		<!--another comment-->
+";
+
 		//args are document, line, col, then the expected sequence of expansions
 		[Test]
 		[TestCase (Document, 1, 2, CommentDoc)]
@@ -98,9 +104,9 @@ a comment-->";
 		[TestCase (Document, 3, 3, "foo", ElementFoo, ElementWithBodyFoo)]
 		[TestCase (Document, 3, 15, "hi", AttributeHello, AttributesFoo, ElementFoo, ElementWithBodyFoo)]
 		[TestCase (Document, 3, 7, "hello", AttributeHello, AttributesFoo, ElementFoo, ElementWithBodyFoo)]
-		[TestCase (Document, 4, 7, TextNode, BodyFoo, ElementWithBodyFoo)]
+		[TestCase (Document, 4, 7, "is", TextNode, TextNodeWithWhitespace, BodyFoo, ElementWithBodyFoo)]
 		[TestCase (Document, 5, 22, "done", AttributeThing, ElementBaz, BodyBar, ElementWithBodyBar, BodyFoo, ElementWithBodyFoo)]
-		[TestCase (Document, 6, 12, CommentBar, BodyBar, ElementWithBodyBar, BodyFoo, ElementWithBodyFoo)]
+		[TestCase (Document, 6, 12, CommentBar, CommentBarWithWhitespace, BodyBar, ElementWithBodyBar, BodyFoo, ElementWithBodyFoo)]
 		public async Task TestExpandShrink (object[] args)
 		{
 			var buffer = CreateTextBuffer ((string)args[0]);

--- a/Editor.Tests/Commands/SmartIndentTests.cs
+++ b/Editor.Tests/Commands/SmartIndentTests.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
+using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.Text.Editor;
 
@@ -27,7 +26,7 @@ namespace MonoDevelop.Xml.Editor.Tests.Commands
 		[TestCase ("<a>w|</a>", 0)] // no indent for closing tag
 		[TestCase ("<a>w| </a>", 0)] // no indent for closing tag preceded by whitespace
 		[TestCase ("<a>|w</a>", 4)] // indent when content is present
-		public void TestSmartIndent (string doc, int expectedIndent)
+		public async Task TestSmartIndent (string doc, int expectedIndent)
 		{
 			var caretPos = doc.IndexOf ('|');
 			if (caretPos > -1) {
@@ -38,7 +37,9 @@ namespace MonoDevelop.Xml.Editor.Tests.Commands
 				doc += "\n";
 			}
 
+			await Catalog.JoinableTaskContext.Factory.SwitchToMainThreadAsync ();
 			var textView = CreateTextView (doc);
+
 			var line = textView.TextBuffer.CurrentSnapshot.GetLineFromPosition (caretPos);
 			GetParser (textView.TextBuffer);
 

--- a/Editor.Tests/EditorCatalog.cs
+++ b/Editor.Tests/EditorCatalog.cs
@@ -33,7 +33,7 @@ namespace MonoDevelop.Xml.Editor.Tests
 		/// <returns>Enumeration of objects of requested type</returns>
 		public IEnumerable<T> GetServices<T> () where T : class => host.GetServices<T> ();
 
-		public ITextViewFactoryService TextViewFactory => GetService<ITextViewFactoryService> ();
+		public ITextEditorFactoryService TextEditorFactory => GetService<ITextEditorFactoryService> ();
 		public ITextDocumentFactoryService TextDocumentFactoryService => GetService<ITextDocumentFactoryService> ();
 		public IFileToContentTypeService FileToContentTypeService => GetService<IFileToContentTypeService> ();
 		public ITextBufferFactoryService BufferFactoryService => GetService<ITextBufferFactoryService> ();

--- a/Editor.Tests/EditorTest.cs
+++ b/Editor.Tests/EditorTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
@@ -26,11 +27,15 @@ namespace MonoDevelop.Xml.Editor.Tests
 
 		public virtual ITextView CreateTextView (string documentText, string filename = null)
 		{
+			if (!Catalog.JoinableTaskContext.IsOnMainThread) {
+				throw new InvalidOperationException ("Must be on main thread");
+			}
+
 			var buffer = CreateTextBuffer (documentText);
 			if (filename != null) {
 				Catalog.TextDocumentFactoryService.CreateTextDocument (buffer, filename);
 			}
-			return Catalog.TextViewFactory.CreateTextView (buffer);
+			return Catalog.TextEditorFactory.CreateTextView (buffer);
 		}
 
 		public virtual ITextBuffer CreateTextBuffer (string documentText)

--- a/Editor.Tests/Extensions/CompletionTestExtensions.cs
+++ b/Editor.Tests/Extensions/CompletionTestExtensions.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion.Data;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 
@@ -14,15 +15,16 @@ namespace MonoDevelop.Xml.Editor.Tests.Extensions
 {
 	public static class CompletionTestExtensions
 	{
-		public static Task<CompletionContext> GetCompletionContext (
+		public static async Task<CompletionContext> GetCompletionContext (
 			this EditorTest test,
 			string documentText, CompletionTriggerReason reason = default, char triggerChar = '\0', char caretMarker = '$', string filename = default, CancellationToken cancellationToken = default)
 		{
 			(documentText, var caretOffset) = TextWithMarkers.ExtractSinglePosition (documentText, caretMarker);
 
+			await test.Catalog.JoinableTaskContext.Factory.SwitchToMainThreadAsync ();
 			var textView = test.CreateTextView (documentText, filename);
 
-			return test.GetCompletionContext (textView, caretOffset, reason, triggerChar, cancellationToken);
+			return await test.GetCompletionContext (textView, caretOffset, reason, triggerChar, cancellationToken);
 		}
 
 		public static async Task<CompletionContext> GetCompletionContext (

--- a/Editor.Tests/Extensions/EditorCommandExtensions.cs
+++ b/Editor.Tests/Extensions/EditorCommandExtensions.cs
@@ -65,9 +65,8 @@ namespace MonoDevelop.Xml.Editor.Tests.Extensions
 			Func<ITextView,Task> initialize = null,
 			CancellationToken cancellationToken = default)
 		{
-			await test.Catalog.JoinableTaskContext.Factory.SwitchToMainThreadAsync (cancellationToken);
-
-			var textView = test.CreateTextView (beforeDocumentText, filename);
+			await test.Catalog.JoinableTaskContext.Factory.SwitchToMainThreadAsync ();
+			var textView = test.CreateTextView(beforeDocumentText, filename);
 			textView.Caret.MoveTo (new SnapshotPoint (textView.TextBuffer.CurrentSnapshot, beforeCaretOffset));
 
 			if (initialize is not null) {

--- a/Editor.Tests/Extensions/QuickInfoTestExtensions.cs
+++ b/Editor.Tests/Extensions/QuickInfoTestExtensions.cs
@@ -13,7 +13,7 @@ namespace MonoDevelop.Xml.Editor.Tests.Extensions
 {
 	public static class QuickInfoTestExtensions
 	{
-		public static Task<QuickInfoItemsCollection> GetQuickInfoItems (
+		public static async Task<QuickInfoItemsCollection> GetQuickInfoItems (
 			this EditorTest test,
 			string documentText,
 			char caretMarker = '$')
@@ -24,8 +24,9 @@ namespace MonoDevelop.Xml.Editor.Tests.Extensions
 			}
 			documentText = documentText.Substring (0, caretOffset) + documentText.Substring (caretOffset + 1);
 
-			var textView = test.CreateTextView (documentText);
-			return test.GetQuickInfoItems (textView, caretOffset);
+			await test.Catalog.JoinableTaskContext.Factory.SwitchToMainThreadAsync ();
+			var textView = test.CreateTextView(documentText);
+			return await test.GetQuickInfoItems (textView, caretOffset);
 		}
 
 		public static async Task<QuickInfoItemsCollection> GetQuickInfoItems (
@@ -36,8 +37,6 @@ namespace MonoDevelop.Xml.Editor.Tests.Extensions
 		{
 			var broker = test.Catalog.AsyncQuickInfoBroker;
 			var snapshot = textView.TextBuffer.CurrentSnapshot;
-
-			await test.Catalog.JoinableTaskContext.Factory.SwitchToMainThreadAsync ();
 
 			var items = await broker.GetQuickInfoItemsAsync (
 				textView,

--- a/Editor.Tests/MiniEditor/CustomErrorHandler.cs
+++ b/Editor.Tests/MiniEditor/CustomErrorHandler.cs
@@ -1,0 +1,31 @@
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.MiniEditor
+{
+	/// <summary>
+	/// Implementation of <see cref="IExtensionErrorHandler"/>.
+	/// Visual Studio provides error handler which writes to activity log and displays messages.
+	/// This implementation forwards the exception to subscribers of <see cref="ExceptionHandled"/> event
+	/// </summary>
+	[Export (typeof (IExtensionErrorHandler))]
+	public class CustomErrorHandler : IExtensionErrorHandler
+	{
+		// GuardedOperations imports IExtensionErrorHandler via Lazy<IExtensionErrorHandler> and
+		// hence gets its own private instance. to access the event from the host we have to make it static
+		public static event EventHandler<ExceptionEventArgs> ExceptionHandled;
+
+		public void HandleError (object sender, Exception exception)
+			=> ExceptionHandled?.Invoke (sender, new ExceptionEventArgs (exception));
+
+		public class ExceptionEventArgs : EventArgs
+		{
+			public Exception Exception { get; }
+			public ExceptionEventArgs (Exception ex)
+			{
+				Exception = ex;
+			}
+		}
+	}
+}

--- a/Editor.Tests/MiniEditor/EditorEnvironment.cs
+++ b/Editor.Tests/MiniEditor/EditorEnvironment.cs
@@ -1,0 +1,256 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License. See License.txt in the project root for license information.
+//
+namespace Microsoft.VisualStudio.MiniEditor
+{
+	using System;
+	using System.Collections.Generic;
+	using System.Collections.Immutable;
+	using System.Linq;
+	using System.Reflection;
+	using System.Runtime.ExceptionServices;
+	using System.Threading.Tasks;
+	using Microsoft.VisualStudio.Composition;
+	using Microsoft.VisualStudio.Text.Editor;
+
+	/// <summary>
+	/// A reusable environment that stores the composition graph. Created using <see cref="InitializeAsync()"/>
+	/// The project that will host the editor must have assemblies specified in <see cref="DefaultAssemblyNames"/> in its output directory. />
+	/// Any additional MEF parts can be added by using an overload of <see cref="InitializeAsync()"/>
+	/// </summary>
+	public class EditorEnvironment
+	{
+		/// <summary>
+		/// Isolated, light weight composition environment
+		/// </summary>
+		public class Host
+		{
+			private ExportProvider _exportProvider;
+
+			/// <summary>
+			/// Creates an export provider which represents a unique container of values.
+			/// You can create as many of these as you want,
+			/// typicall each test has its own Host, and an application has a single Host.
+			/// </summary>
+			internal Host(IExportProviderFactory epf)
+			{
+				_exportProvider = epf.CreateExportProvider();
+			}
+
+			/// <summary>
+			/// Gets a service of specified type from the composition graph
+			/// </summary>
+			/// <typeparam name="T">Service type</typeparam>
+			/// <returns>Object of requested type</returns>
+			public T GetService<T>() where T : class
+			{
+				return _exportProvider.GetExportedValue<T>();
+			}
+
+			/// <summary>
+			/// Gets services of specified type from the composition graph
+			/// </summary>
+			/// <typeparam name="T">Service type</typeparam>
+			/// <returns>Enumeration of objects of requested type</returns>
+			public IEnumerable<T> GetServices<T>() where T : class
+			{
+				return _exportProvider.GetExportedValues<T>();
+			}
+		}
+
+		/// <summary>
+		/// Contains the composition graph, builds independent composition environments
+		/// </summary>
+		private IExportProviderFactory _epf;
+
+		/// <summary>
+		/// Provides a list of assembly names that contain parts needed to bootstrap editor with its standard features.
+		/// Also provides names of packages that contain these assemblies
+		/// </summary>
+		/// <remarks>
+		/// Any additional assemblies to the specific integration test should be added using an overload of <see cref="InitializeAsync()"/>.
+		/// </remarks>
+		/// <returns>An array of assembly names</returns>
+		public static readonly ImmutableArray<string> DefaultAssemblyNames = new []
+		{
+			// list of assemblies comes from https://github.com/dotnet/roslyn/blob/5cba0ce666766b1db7cd75009575c7e12c4be72c/src/EditorFeatures/TestUtilities/EditorTestCompositions.cs#L24
+			"Microsoft.VisualStudio.Platform.VSEditor.dll",
+			"Microsoft.VisualStudio.Text.Logic.dll",
+			"Microsoft.VisualStudio.Text.UI.dll",
+			"Microsoft.VisualStudio.Text.UI.Wpf.dll",
+			"BasicUndo.dll",
+			"Microsoft.VisualStudio.Language.StandardClassification.dll",
+			"Microsoft.VisualStudio.Language.dll",
+			"Microsoft.VisualStudio.CoreUtility.dll"
+		}.ToImmutableArray();
+
+		/// <summary>
+		/// Acommodates modification of the list of assembly names used to boostrap editor with its standard features.
+		/// This property defaults to <see cref="DefaultAssemblyNames"/> and may be changed before <see cref="InitializeAsync()"/> is invoked.
+		/// This is made available so that VS4mac may experiment with WPF-free implementation. Good luck!
+		/// </summary>
+		public static ImmutableArray<string> DefaultAssemblies { get; set; } = DefaultAssemblyNames;
+
+		/// <summary>
+		/// Gets isolated, light weight composition environment for a specific test.
+		/// Ideally, each test has its own <see cref="Host"/> obtained by calling this method in the test initialization method.
+		/// </summary>
+		/// <returns>Isolated instance of composition environment that provides MEF parts.</returns>
+		public Host GetEditorHost()
+		{
+			return new Host(_epf);
+		}
+
+		/// <summary>
+		/// Contains composition errors. Array is empty if there were no composition errors.
+		/// </summary>
+		public ImmutableArray<string> CompositionErrors { get; }
+
+		// --- private constructor and public static initialization methods: ---
+
+		/// <summary>
+		/// Creates a reusable environment with a specified composition graph.
+		/// </summary>
+		private EditorEnvironment(IExportProviderFactory epf, ImmutableArray<string> compositionErrors)
+		{
+			_epf = epf;
+			CompositionErrors = compositionErrors;
+		}
+
+		/// <summary>
+		/// Creates a reusable environment that consists of default parts needed to bootstrap the editor.
+		/// </summary>
+		/// <returns>Composed environment that can be reused across tests</returns>
+		public static async Task<EditorEnvironment> InitializeAsync()
+		{
+			return await InitializeAsync(assembliesToLoad: null, typesToLoad: null, typesThatOverride: null);
+		}
+
+		/// <summary>
+		/// Creates a reusable environment that consists of default parts needed to bootstrap the editor,
+		/// as well as parts found in the provided assemblies.
+		/// </summary>
+		/// <param name="assembliesToLoad">Filenames of assemblies that will be searched for MEF parts.</param>
+		/// <returns>Composed environment that can be reused across tests</returns>
+		public static async Task<EditorEnvironment> InitializeAsync(params string[] assembliesToLoad)
+		{
+			return await InitializeAsync(assembliesToLoad, null, null);
+		}
+
+		/// <summary>
+		/// Creates a reusable environment that consists of default parts needed to bootstrap the editor,
+		/// as well as parts found in the provided types.
+		/// </summary>
+		/// <param name="typesToLoad">Types to include in the MEF catalog.</param>
+		/// <returns>Composed environment that can be reused across tests</returns>
+		public static async Task<EditorEnvironment> InitializeAsync(params Type[] typesToLoad)
+		{
+			return await InitializeAsync(null, typesToLoad, null);
+		}
+
+		/// <summary>
+		/// Creates a reusable environment that consists of parts found in the provided <paramref name="typesToLoad"></paramref>
+		/// as well as default parts needed to bootstrap the editor, except for parts whose metadata matches these from <paramref name="typesThatOverride"></paramref>.
+		/// The overriding of default parts is useful when providing mocks.
+		/// </summary>
+		/// <param name="typesToLoad">Types to include in the MEF catalog.</param>
+		/// <param name="typesThatOverride">Types whose export signatures will be used to filter out the default catalog.</param>
+		/// <returns>Composed environment that can be reused across tests</returns>
+		public static async Task<EditorEnvironment> InitializeAsync(IEnumerable<Type> typesToLoad, IEnumerable<Type> typesThatOverride)
+		{
+			return await InitializeAsync(null, typesToLoad, typesThatOverride);
+		}
+
+		/// <summary>
+		/// Creates a reusable environment that consists of
+		/// 1) default parts and parts needed to bootstrap the editor, except for parts whose metadata matches these from <paramref name="typesThatOverride"></paramref>
+		/// 2) parts found in the provided assemblies
+		/// 3) parts found in the provided types.
+		/// </summary>
+		/// <param name="assembliesToLoad">Filenames of assemblies that will be searched for MEF parts.</param>
+		/// <param name="typesToLoad">Types to include in the MEF catalog.</param>
+		/// <param name="typesThatOverride">Types whose export signatures will be used to filter out the default catalog.</param>
+		/// <returns>Composed environment that can be reused across tests</returns>
+		public static async Task<EditorEnvironment> InitializeAsync(IEnumerable<string> assembliesToLoad, IEnumerable<Type> typesToLoad, IEnumerable<Type> typesThatOverride)
+		{
+			// Prepare part discovery to support both flavors of MEF attributes.
+			var discovery = PartDiscovery.Combine(
+				new AttributedPartDiscovery(Resolver.DefaultInstance, isNonPublicSupported: true), // "NuGet MEF" attributes (Microsoft.Composition)
+				new AttributedPartDiscoveryV1(Resolver.DefaultInstance)); // ".NET MEF" attributes (System.ComponentModel.Composition)
+
+			var assemblyCatalog = ComposableCatalog.Create(Resolver.DefaultInstance);
+
+			// Create a list of parts that should override the defaults. Used for mocking when Import expects only one part.
+			IEnumerable<ComposablePartDefinition> partsThatOverride = null;
+			if (typesThatOverride != null)
+			{
+				partsThatOverride = (await discovery.CreatePartsAsync(typesThatOverride)).Parts;
+			}
+
+			// Load default parts
+			foreach (var assemblyName in DefaultAssemblies)
+			{
+				try
+				{
+					var parts = (await discovery.CreatePartsAsync(Assembly.LoadFrom(assemblyName))).Parts;
+					if (partsThatOverride != null)
+					{
+						// Exclude parts whose contract matches the contract of any of the overriding parts
+						var overriddenParts = parts.Where(defaultPart => defaultPart.ExportedTypes.Any(defaultType =>
+							partsThatOverride.Any(overridingPart => overridingPart.ExportedTypes.Any(overridingType => overridingType.ContractName == defaultType.ContractName))));
+						parts = parts.Except(overriddenParts);
+					}
+					assemblyCatalog = assemblyCatalog.AddParts(parts);
+				}
+				catch (System.IO.FileNotFoundException)
+				{
+					// Note, if we provide inner exception, the MSTest runner will display it instead of informativeException. For this reason, we don't provide inner exception.
+					var informativeException = new InvalidOperationException($"Required assembly `{assemblyName}` not found. Please place it in this process' working directory. You can do it by adding reference to the NuGet package that contains this assembly.");
+					informativeException.Data["Missing file"] = assemblyName;
+					throw informativeException;
+				}
+			}
+
+			// Load parts from all types in the specified assemblies
+			if (assembliesToLoad != null)
+			{
+				foreach (string assembly in assembliesToLoad)
+				{
+					var parts = await discovery.CreatePartsAsync(Assembly.LoadFrom(assembly));
+					assemblyCatalog = assemblyCatalog.AddParts(parts);
+				}
+			}
+
+			// Load parts from the specified types
+			if (typesToLoad != null)
+			{
+				var parts = await discovery.CreatePartsAsync(typesToLoad);
+				assemblyCatalog = assemblyCatalog.AddParts(parts);
+			}
+
+			// TODO: see if this will be useful
+			assemblyCatalog = assemblyCatalog.WithCompositionService(); // Makes an ICompositionService export available to MEF parts to import.
+
+			// Assemble the parts into a valid graph.
+			var compositionConfiguration = CompositionConfiguration.Create(assemblyCatalog);
+
+			ImmutableArray<string> compositionErrors = ImmutableArray<string>.Empty;
+			if (compositionConfiguration.CompositionErrors.Any())
+			{
+				compositionErrors = compositionConfiguration.CompositionErrors.SelectMany(collection => collection.Select(diagnostic => diagnostic.Message)).ToImmutableArray();
+				// Uncomment to investigate errors and continue execution
+				// Debugger.Break();
+
+				// Uncomment to fail immediately:
+				// var exception = new InvalidOperationException("There were composition errors");
+				// exception.Data["Errors"] = errors;
+				// throw exception;
+			}
+
+			// Prepare an ExportProvider factory based on this graph.
+			// This factory can be now re-used across tests
+			return new EditorEnvironment(compositionConfiguration.CreateExportProviderFactory(), compositionErrors);
+		}
+	}
+}

--- a/Editor.Tests/MiniEditor/LICENSE
+++ b/Editor.Tests/MiniEditor/LICENSE
@@ -1,0 +1,27 @@
+# MiniEditor
+
+MiniEditor code is imported from https://github.com/mhutch/MiniEditor,
+which was forked from https://github.com/garuma/MiniEditor, and is licensed
+under the MIT License:
+
+## MIT License
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Editor.Tests/MiniEditor/TestCommandHandlers.cs
+++ b/Editor.Tests/MiniEditor/TestCommandHandlers.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel.Composition;
+
+using Microsoft.VisualStudio.Commanding;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Editor.Commanding.Commands;
+using Microsoft.VisualStudio.Text.Operations;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.MiniEditor.BaseViewImpl
+{
+	[Name (Name)]
+	[ContentType (StandardContentTypeNames.Any)]
+	[TextViewRole (PredefinedTextViewRoles.Interactive)]
+	[Export (typeof (ICommandHandler))]
+	public class TestCommandHandlers :
+		ICommandHandler<TypeCharCommandArgs>,
+		ICommandHandler<ReturnKeyCommandArgs>
+	{
+		const string Name = nameof (TestCommandHandlers);
+
+		[Import]
+		IEditorOperationsFactoryService OperationsServiceFactory { get; set; }
+		IEditorOperations3 GetOperations (ITextView tv) =>
+			(IEditorOperations3) OperationsServiceFactory.GetEditorOperations (tv);
+
+		public string DisplayName => Name;
+
+		public bool ExecuteCommand (TypeCharCommandArgs args, CommandExecutionContext executionContext)
+			=> GetOperations (args.TextView).InsertText (args.TypedChar.ToString ());
+
+		public CommandState GetCommandState (TypeCharCommandArgs args)
+			=> args.TypedChar == '\0'? CommandState.Unavailable : CommandState.Available;
+
+		public CommandState GetCommandState (ReturnKeyCommandArgs args)
+			=> CommandState.Available;
+
+		public bool ExecuteCommand (ReturnKeyCommandArgs args, CommandExecutionContext executionContext)
+			=> GetOperations (args.TextView).InsertNewLine ();
+	}
+}

--- a/Editor.Tests/MonoDevelop.Xml.Editor.Tests.csproj
+++ b/Editor.Tests/MonoDevelop.Xml.Editor.Tests.csproj
@@ -50,5 +50,8 @@
     <PackageReference Include="Microsoft.VisualStudio.Text.Internal" />
     <PackageReference Include="BasicUndo" />
     <PackageReference Include="Microsoft.VisualStudio.Language" />
+    <!-- upgrade vulnerable transitive dependencies -->
+    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="Microsoft.IO.Redist" />
   </ItemGroup>
 </Project>

--- a/Editor.Tests/MonoDevelop.Xml.Editor.Tests.csproj
+++ b/Editor.Tests/MonoDevelop.Xml.Editor.Tests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">net48;net8.0</TargetFrameworks>
+    <TargetFramework>net48</TargetFramework>
     <NUnitDisableSupportAssemblies>true</NUnitDisableSupportAssemblies>
   </PropertyGroup>
 

--- a/Editor.Tests/MonoDevelop.Xml.Editor.Tests.csproj
+++ b/Editor.Tests/MonoDevelop.Xml.Editor.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">net48;net8.0</TargetFrameworks>
     <NUnitDisableSupportAssemblies>true</NUnitDisableSupportAssemblies>
   </PropertyGroup>
 

--- a/Editor.Tests/MonoDevelop.Xml.Editor.Tests.csproj
+++ b/Editor.Tests/MonoDevelop.Xml.Editor.Tests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48</TargetFrameworks>
     <NUnitDisableSupportAssemblies>true</NUnitDisableSupportAssemblies>
   </PropertyGroup>
 
@@ -10,7 +9,9 @@
     <ProjectReference Include="..\Core\MonoDevelop.Xml.Core.csproj" />
     <ProjectReference Include="..\Core.Tests\MonoDevelop.Xml.Core.Tests.csproj" />
     <ProjectReference Include="..\Editor\MonoDevelop.Xml.Editor.csproj" />
+    <!--
     <ProjectReference Include="..\external\MiniEditor\Microsoft.VisualStudio.MiniEditor\Microsoft.VisualStudio.MiniEditor.csproj" NoWarn="NU1701" />
+    -->
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Schema\SchemaAssociationTests.cs" />
@@ -26,10 +27,28 @@
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit.Analyzers" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" NoWarn="NU1701" />
-    <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" NoWarn="NU1701" />
-    <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" NoWarn="NU1701" />
+    <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" />
+    <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" />
+    <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" />
+    <PackageReference Include="Microsoft.VisualStudio.Editor" />
+    <!--
+    Most of these references are to resolve issues in Microsoft.VisualStudio.Editor,
+    which frequently has dependencies with versions that are not published on NuGet.or
+    -->
     <PackageReference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" />
+    <PackageReference Include="Microsoft.VisualStudio.Utilities" />
+    <PackageReference Include="Microsoft.VisualStudio.Interop" />
+    <PackageReference Include="Microsoft.VisualStudio.GraphModel" />
+    <PackageReference Include="Microsoft.VisualStudio.Imaging" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" />
+    <!-- fix issue where Microsoft.VisualStudio.Language.Intellisense depends on StreamJsonRpc version not present in public feeds -->
+    <PackageReference Include="StreamJsonRpc" />
+    <!-- needed for editor composition -->
+    <PackageReference Include="Microsoft.VisualStudio.Platform.VSEditor" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.Internal" />
+    <PackageReference Include="BasicUndo" />
+    <PackageReference Include="Microsoft.VisualStudio.Language" />
   </ItemGroup>
 </Project>

--- a/Editor.Tests/Tagging/HighlightEndTagTaggerTests.cs
+++ b/Editor.Tests/Tagging/HighlightEndTagTaggerTests.cs
@@ -10,6 +10,7 @@ using MonoDevelop.Xml.Tests;
 using MonoDevelop.Xml.Tests.Utils;
 
 using NUnit.Framework;
+using NUnit.Framework.Internal;
 
 namespace MonoDevelop.Xml.Editor.Tests.Tagging;
 
@@ -22,7 +23,8 @@ public class HighlightEndTagTaggerTests : HighlightTaggerTest<NavigableHighlight
 		var text = TextWithMarkers.Parse ("<^foo^><></^foo^>", '^');
 		var spans = text.GetMarkedSpans ('^');
 
-		var textView = CreateTextView (text.Text);
+		await Catalog.JoinableTaskContext.Factory.SwitchToMainThreadAsync ();
+		var textView = CreateTextView(text.Text);
 
 		var logger = TestLoggerFactory.CreateTestMethodLogger ().RethrowExceptions ();
 

--- a/Editor.Tests/Tagging/HighlightTaggerTest.cs
+++ b/Editor.Tests/Tagging/HighlightTaggerTest.cs
@@ -25,7 +25,7 @@ public abstract class HighlightTaggerTest<TTag, TKind> : XmlEditorTest where TTa
 
 	protected async Task<List<Highlight>> GetAllHighlights (ITextView textView, HighlightTagger<TTag, TKind> tagger)
 	{
-		var highlights = await GetAllHighlightsInner (textView, tagger).ConfigureAwait (false);
+		var highlights = await GetAllHighlightsInner (textView, tagger);
 
 		return highlights.Select (kv => new Highlight (
 				new TextSpan (kv.Key.Start, kv.Key.Length),
@@ -43,7 +43,7 @@ public abstract class HighlightTaggerTest<TTag, TKind> : XmlEditorTest where TTa
 			textView.Caret.MoveTo (new SnapshotPoint (textView.TextBuffer.CurrentSnapshot, i));
 
 			// return null if it was cancelled or nothing changed
-			var updateResult = await UpdateHighlightsAsync (tagger).ConfigureAwait (false);
+			var updateResult = await UpdateHighlightsAsync (tagger);
 			if (updateResult is null) {
 				continue;
 			}

--- a/Editor.Tests/Utils/MockMainLoop.cs
+++ b/Editor.Tests/Utils/MockMainLoop.cs
@@ -47,11 +47,14 @@ namespace MonoDevelop.Xml.Editor.Tests.Utils
 		{
 			var readyTask = new TaskCompletionSource<bool> ();
 			MainThread = new Thread (Run) { IsBackground = true };
+			MainThread.SetApartmentState (ApartmentState.STA);
 			MainThread.Start (readyTask);
 
+#pragma warning disable VSSDK005 // Avoid instantiating JoinableTaskContext
 			JoinableTaskContext = new JoinableTaskContext (MainThread, this);
+#pragma warning restore VSSDK005 // Avoid instantiating JoinableTaskContext
 
-			#pragma warning disable VSTHRD002 // This just signals the thread was started
+#pragma warning disable VSTHRD002 // This just signals the thread was started
 			readyTask.Task.Wait ();
 			#pragma warning restore VSTHRD002
 		}

--- a/Editor/Completion/XmlCompletionCommitManager.cs
+++ b/Editor/Completion/XmlCompletionCommitManager.cs
@@ -51,11 +51,16 @@ class XmlCompletionCommitManager (ILogger logger, JoinableTaskContext joinableTa
 		switch (trigger) {
 		case XmlCompletionTrigger.Tag:
 		case XmlCompletionTrigger.ElementName:
+		case XmlCompletionTrigger.ElementValue:
 			// allow using / as a commit char for elements as self-closing elements, but special case disallowing it
 			// in the cases where that could conflict with typing the / at the start of a closing tag
 			if (typedChar == '/') {
 				var span = session.ApplicableToSpan.GetSpan (snapshot);
-				if (span.Length == (trigger == XmlCompletionTrigger.ElementName ? 0 : 1)) {
+				if (trigger switch {
+					XmlCompletionTrigger.ElementName => span.Length == 0,
+					// XmlCompletionTrigger.ElementValue may have values that are not tags so check the < as well
+					_ => span.Length == 1 && snapshot[span.Start] == '<'
+				}) {
 					return false;
 				}
 			}

--- a/Editor/MonoDevelop.Xml.Editor.csproj
+++ b/Editor/MonoDevelop.Xml.Editor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Editor/MonoDevelop.Xml.Editor.csproj
+++ b/Editor/MonoDevelop.Xml.Editor.csproj
@@ -11,6 +11,8 @@
     <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" ExcludeAssets="runtime" NoWarn="NU1701" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" ExcludeAssets="runtime" />
+    <!-- fix issue where Microsoft.VisualStudio.Language.Intellisense depends on StreamJsonRpc version not present in public feeds -->
+    <PackageReference Include="StreamJsonRpc" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Editor/MonoDevelop.Xml.Editor.csproj
+++ b/Editor/MonoDevelop.Xml.Editor.csproj
@@ -13,6 +13,8 @@
     <PackageReference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" ExcludeAssets="runtime" />
     <!-- fix issue where Microsoft.VisualStudio.Language.Intellisense depends on StreamJsonRpc version not present in public feeds -->
     <PackageReference Include="StreamJsonRpc" ExcludeAssets="runtime" />
+    <!-- upgrade vulnerable transitive dependencies -->
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MonoDevelop.Xml.sln
+++ b/MonoDevelop.Xml.sln
@@ -6,8 +6,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonoDevelop.Xml.Core", "Cor
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonoDevelop.Xml.Editor", "Editor\MonoDevelop.Xml.Editor.csproj", "{21DCB152-D50D-48E9-B1AA-FB341192D88F}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.MiniEditor", "external\MiniEditor\Microsoft.VisualStudio.MiniEditor\Microsoft.VisualStudio.MiniEditor.csproj", "{63921982-748E-4CB8-80A9-84E14FB60E1B}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonoDevelop.Xml.Core.Tests", "Core.Tests\MonoDevelop.Xml.Core.Tests.csproj", "{69E2900F-EF2E-458A-9AC8-03954B269778}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonoDevelop.Xml.Editor.Tests", "Editor.Tests\MonoDevelop.Xml.Editor.Tests.csproj", "{CE361B05-2E2B-4FEE-9889-D4F00F88C5CC}"
@@ -17,18 +15,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
 		Directory.Packages.props = Directory.Packages.props
-	EndProjectSection
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "MiniEditor", "MiniEditor", "{EFA73B0E-5240-4FE6-8E78-9E524A70519F}"
-	ProjectSection(SolutionItems) = preProject
-		external\MiniEditor\Directory.Build.props = external\MiniEditor\Directory.Build.props
-		external\MiniEditor\Directory.Packages.props = external\MiniEditor\Directory.Packages.props
+		NuGet.Config = NuGet.Config
 	EndProjectSection
 EndProject
 Global
-	GlobalSection(NestedProjects) = preSolution
-		{63921982-748E-4CB8-80A9-84E14FB60E1B} = {EFA73B0E-5240-4FE6-8E78-9E524A70519F}
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
@@ -42,10 +32,6 @@ Global
 		{21DCB152-D50D-48E9-B1AA-FB341192D88F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{21DCB152-D50D-48E9-B1AA-FB341192D88F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{21DCB152-D50D-48E9-B1AA-FB341192D88F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{63921982-748E-4CB8-80A9-84E14FB60E1B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{63921982-748E-4CB8-80A9-84E14FB60E1B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{63921982-748E-4CB8-80A9-84E14FB60E1B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{63921982-748E-4CB8-80A9-84E14FB60E1B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{69E2900F-EF2E-458A-9AC8-03954B269778}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{69E2900F-EF2E-458A-9AC8-03954B269778}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{69E2900F-EF2E-458A-9AC8-03954B269778}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/NoVSEditor.slnf
+++ b/NoVSEditor.slnf
@@ -1,0 +1,9 @@
+{
+  "solution": {
+    "path": "MonoDevelop.Xml.sln",
+    "projects": [
+      "Core.Tests\\MonoDevelop.Xml.Core.Tests.csproj",
+      "Core\\MonoDevelop.Xml.Core.csproj"
+    ]
+  }
+}

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,4 +4,13 @@
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="vs-impl">
+      <package pattern="Microsoft.VisualStudio.Platform.VSEditor" />
+      <package pattern="Microsoft.VisualStudio.Text.Internal" />
+    </packageSource>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,6 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
VS Editor added an internal `Disconnect()` member to the `IConnectedSpan` interface in 17.6, which meant that MiniEditor could not implement any version of the VS Editor APIs newer than 17.5.

Not being able to update the VS Editor packages caused issues for MSBuildEditor, especially when it needed to bring in newer versions of Roslyn for the LSP.

Fix this by removing MiniEditor and instead using the VS Editor itself to run the tests, mimicking how Roslyn does it. This has the downside that we can no longer run the editor tests on Mac. However, as Visual Studio for Mac is now discontinued, this is no longer a pressing concern.