### PR TITLE
Supports attaching arbitrary node to XObject

### DIFF
--- a/Core/Dom/XObject.cs
+++ b/Core/Dom/XObject.cs
@@ -39,6 +39,9 @@ namespace MonoDevelop.Xml.Dom
 
 		public XObject? Parent { get; internal protected set; }
 
+		// supports attaching arbitrary nodes
+		public XNode? Node { get; set; }
+
 		public IEnumerable<XNode> Parents {
 			get {
 				var next = Parent as XNode;


### PR DESCRIPTION
Addresses #103.

This pull requests adds a new `XNode? Node` public property to `XObject` to support attaching arbitrary nodes to the DOM.