### PR TITLE
Enforced strict error on malformed self-closing tag.

### DIFF
--- a/Core.Tests/Parser/ParsingTests.cs
+++ b/Core.Tests/Parser/ParsingTests.cs
@@ -223,6 +223,18 @@ namespace MonoDevelop.Xml.Tests.Parser
 		}
 
 		[Test]
+		public void MalformedSelfClosingTag ()
+		{
+			var parser = new XmlTreeParser (CreateRootState ());
+			var result = parser.Parse (@"<root / >");
+
+			parser.AssertDiagnostics (
+				(XmlCoreDiagnostics.MalformedSelfClosingTag, 7, 0),
+				(XmlCoreDiagnostics.IncompleteTagEof, 9, 0)
+				);
+		}
+
+		[Test]
 		public void MismatchedElementNameWithNamespace ()
 		{
 			var docTxt = "<X><n:></a><b></X>";
@@ -417,8 +429,8 @@ namespace MonoDevelop.Xml.Tests.Parser
 			result.AssertNoDiagnostics ();
 
 			var el = result.doc
-				.RootElement.AssertNotNull()
-				.FirstChild.AssertCast<XElement>();
+				.RootElement.AssertNotNull ()
+				.FirstChild.AssertCast<XElement> ();
 			Assert.AreEqual (2, el.Nodes.Count ());
 			var b = el.FirstChild as XElement;
 			Assert.NotNull (b);
@@ -438,7 +450,7 @@ namespace MonoDevelop.Xml.Tests.Parser
 </foo>
 ";
 			var parser = new XmlTreeParser (CreateRootState ());
-			var result = parser.Parse(docTxt, preserveWindowsNewlines: true);
+			var result = parser.Parse (docTxt, preserveWindowsNewlines: true);
 
 			var rootElement = result.doc.RootElement.AssertNotNull ();
 
@@ -446,13 +458,13 @@ namespace MonoDevelop.Xml.Tests.Parser
 
 			AssertSubstring (@"<foo someAtt=""SomeVal"">", rootElement);
 			AssertSubstring (@"someAtt=""SomeVal""", rootElement.Attributes.First.AssertNotNull ());
-			AssertSubstring (@"<!-- blah -->", rootElement.Nodes.OfType<XComment>().First ());
-			AssertSubstring (@"<![CDATA[ dfdfdf ]]>", rootElement.Nodes.OfType<XCData>().First ());
+			AssertSubstring (@"<!-- blah -->", rootElement.Nodes.OfType<XComment> ().First ());
+			AssertSubstring (@"<![CDATA[ dfdfdf ]]>", rootElement.Nodes.OfType<XCData> ().First ());
 			AssertSubstring (@"</foo>", rootElement.ClosingTag.AssertNotNull ());
 		}
 
 		[Test]
-		public void ProcessingInstruction()
+		public void ProcessingInstruction ()
 		{
 			var docTxt = @"<?x?>";
 
@@ -603,7 +615,7 @@ namespace MonoDevelop.Xml.Tests.Parser
 			AssertEqual (a.KeywordBuilder, b.KeywordBuilder);
 
 			Assert.AreEqual (a.Nodes.Count, b.Nodes.Count);
-			Assert.AreEqual (a.Nodes.Peek().GetType(), b.Nodes.Peek().GetType());
+			Assert.AreEqual (a.Nodes.Peek ().GetType (), b.Nodes.Peek ().GetType ());
 		}
 
 		// avoid allocating strings unless they're not equal

--- a/Core.Tests/Parser/ParsingTests.cs
+++ b/Core.Tests/Parser/ParsingTests.cs
@@ -429,8 +429,8 @@ namespace MonoDevelop.Xml.Tests.Parser
 			result.AssertNoDiagnostics ();
 
 			var el = result.doc
-				.RootElement.AssertNotNull ()
-				.FirstChild.AssertCast<XElement> ();
+				.RootElement.AssertNotNull()
+				.FirstChild.AssertCast<XElement>();
 			Assert.AreEqual (2, el.Nodes.Count ());
 			var b = el.FirstChild as XElement;
 			Assert.NotNull (b);
@@ -450,7 +450,7 @@ namespace MonoDevelop.Xml.Tests.Parser
 </foo>
 ";
 			var parser = new XmlTreeParser (CreateRootState ());
-			var result = parser.Parse (docTxt, preserveWindowsNewlines: true);
+			var result = parser.Parse(docTxt, preserveWindowsNewlines: true);
 
 			var rootElement = result.doc.RootElement.AssertNotNull ();
 
@@ -458,13 +458,13 @@ namespace MonoDevelop.Xml.Tests.Parser
 
 			AssertSubstring (@"<foo someAtt=""SomeVal"">", rootElement);
 			AssertSubstring (@"someAtt=""SomeVal""", rootElement.Attributes.First.AssertNotNull ());
-			AssertSubstring (@"<!-- blah -->", rootElement.Nodes.OfType<XComment> ().First ());
-			AssertSubstring (@"<![CDATA[ dfdfdf ]]>", rootElement.Nodes.OfType<XCData> ().First ());
+			AssertSubstring (@"<!-- blah -->", rootElement.Nodes.OfType<XComment>().First ());
+			AssertSubstring (@"<![CDATA[ dfdfdf ]]>", rootElement.Nodes.OfType<XCData>().First ());
 			AssertSubstring (@"</foo>", rootElement.ClosingTag.AssertNotNull ());
 		}
 
 		[Test]
-		public void ProcessingInstruction ()
+		public void ProcessingInstruction()
 		{
 			var docTxt = @"<?x?>";
 
@@ -615,7 +615,7 @@ namespace MonoDevelop.Xml.Tests.Parser
 			AssertEqual (a.KeywordBuilder, b.KeywordBuilder);
 
 			Assert.AreEqual (a.Nodes.Count, b.Nodes.Count);
-			Assert.AreEqual (a.Nodes.Peek ().GetType (), b.Nodes.Peek ().GetType ());
+			Assert.AreEqual (a.Nodes.Peek().GetType(), b.Nodes.Peek().GetType());
 		}
 
 		// avoid allocating strings unless they're not equal

--- a/Core.Tests/Parser/ParsingTests.cs
+++ b/Core.Tests/Parser/ParsingTests.cs
@@ -226,11 +226,14 @@ namespace MonoDevelop.Xml.Tests.Parser
 		public void MalformedSelfClosingTag ()
 		{
 			var parser = new XmlTreeParser (CreateRootState ());
-			var result = parser.Parse (@"<root / >");
+			var result = parser.Parse (@"<root / $>",
+
+				() => {
+					parser.AssertStateIs<XmlTagState> ();
+				});
 
 			parser.AssertDiagnostics (
-				(XmlCoreDiagnostics.MalformedSelfClosingTag, 7, 0),
-				(XmlCoreDiagnostics.IncompleteTagEof, 9, 0)
+				(XmlCoreDiagnostics.MalformedSelfClosingTag, 7, 0)
 				);
 		}
 

--- a/Core/Parser/XmlTagState.cs
+++ b/Core/Parser/XmlTagState.cs
@@ -41,16 +41,16 @@ namespace MonoDevelop.Xml.Parser
 
 		const int ATTEMPT_RECOVERY = 1;
 		const int RECOVERY_FOUND_WHITESPACE = 2;
-		const int MAYBE_SELF_CLOSING = 2;
+		const int MAYBE_SELF_CLOSING = 3;
 		const int FREE = 0;
 
 		readonly XmlAttributeState AttributeState;
 		readonly XmlNameState NameState;
 
-		public XmlTagState () : this (new XmlAttributeState ()) {}
+		public XmlTagState () : this (new XmlAttributeState ()) { }
 
-		public XmlTagState  (XmlAttributeState attributeState)
-			: this (attributeState, new XmlNameState ()) {}
+		public XmlTagState (XmlAttributeState attributeState)
+			: this (attributeState, new XmlNameState ()) { }
 
 		public XmlTagState (XmlAttributeState attributeState, XmlNameState nameState)
 		{
@@ -63,7 +63,7 @@ namespace MonoDevelop.Xml.Parser
 
 		public override XmlParserState? PushChar (char c, XmlParserContext context, ref bool replayCharacter, bool isEndOfFile)
 		{
-			var peekedNode = (XContainer) context.Nodes.Peek ();
+			var peekedNode = (XContainer)context.Nodes.Peek ();
 			var element = peekedNode as XElement;
 
 			// if the current node on the stack is ended or not an element, then it's the parent
@@ -87,8 +87,7 @@ namespace MonoDevelop.Xml.Parser
 				}
 				if (isEndOfFile) {
 					context.Diagnostics?.Add (XmlCoreDiagnostics.IncompleteTagEof, context.PositionBeforeCurrentChar);
-				}
-				else if (element.Name.IsValid) {
+				} else if (element.Name.IsValid) {
 					context.Diagnostics?.Add (XmlCoreDiagnostics.MalformedNamedTag, context.PositionBeforeCurrentChar, element.Name.FullName, '<');
 				} else {
 					context.Diagnostics?.Add (XmlCoreDiagnostics.UnnamedTag, context.PositionBeforeCurrentChar);
@@ -137,6 +136,11 @@ namespace MonoDevelop.Xml.Parser
 			if (c == '/') {
 				context.StateTag = MAYBE_SELF_CLOSING;
 				return null;
+			}
+
+			if (context.StateTag == MAYBE_SELF_CLOSING) {
+				context.Diagnostics?.Add (XmlCoreDiagnostics.MalformedSelfClosingTag, context.Position, c);
+				return Parent;
 			}
 
 			if (context.StateTag == ATTEMPT_RECOVERY) {

--- a/Core/Parser/XmlTagState.cs
+++ b/Core/Parser/XmlTagState.cs
@@ -141,7 +141,7 @@ namespace MonoDevelop.Xml.Parser
 
 			if (context.StateTag == MAYBE_SELF_CLOSING) {
 				context.Diagnostics?.Add (XmlCoreDiagnostics.MalformedSelfClosingTag, context.Position, c);
-				return this;
+				return null;
 			}
 
 			if (context.StateTag == ATTEMPT_RECOVERY) {

--- a/Core/Parser/XmlTagState.cs
+++ b/Core/Parser/XmlTagState.cs
@@ -141,7 +141,7 @@ namespace MonoDevelop.Xml.Parser
 
 			if (context.StateTag == MAYBE_SELF_CLOSING) {
 				context.Diagnostics?.Add (XmlCoreDiagnostics.MalformedSelfClosingTag, context.Position, c);
-				return Parent;
+				return this;
 			}
 
 			if (context.StateTag == ATTEMPT_RECOVERY) {

--- a/Core/Parser/XmlTagState.cs
+++ b/Core/Parser/XmlTagState.cs
@@ -47,10 +47,10 @@ namespace MonoDevelop.Xml.Parser
 		readonly XmlAttributeState AttributeState;
 		readonly XmlNameState NameState;
 
-		public XmlTagState () : this (new XmlAttributeState ()) { }
+		public XmlTagState () : this (new XmlAttributeState ()) {}
 
-		public XmlTagState (XmlAttributeState attributeState)
-			: this (attributeState, new XmlNameState ()) { }
+		public XmlTagState  (XmlAttributeState attributeState)
+			: this (attributeState, new XmlNameState ()) {}
 
 		public XmlTagState (XmlAttributeState attributeState, XmlNameState nameState)
 		{
@@ -63,7 +63,7 @@ namespace MonoDevelop.Xml.Parser
 
 		public override XmlParserState? PushChar (char c, XmlParserContext context, ref bool replayCharacter, bool isEndOfFile)
 		{
-			var peekedNode = (XContainer)context.Nodes.Peek ();
+			var peekedNode = (XContainer) context.Nodes.Peek ();
 			var element = peekedNode as XElement;
 
 			// if the current node on the stack is ended or not an element, then it's the parent
@@ -87,7 +87,8 @@ namespace MonoDevelop.Xml.Parser
 				}
 				if (isEndOfFile) {
 					context.Diagnostics?.Add (XmlCoreDiagnostics.IncompleteTagEof, context.PositionBeforeCurrentChar);
-				} else if (element.Name.IsValid) {
+				}
+				else if (element.Name.IsValid) {
 					context.Diagnostics?.Add (XmlCoreDiagnostics.MalformedNamedTag, context.PositionBeforeCurrentChar, element.Name.FullName, '<');
 				} else {
 					context.Diagnostics?.Add (XmlCoreDiagnostics.UnnamedTag, context.PositionBeforeCurrentChar);


### PR DESCRIPTION
Fixes #109.

This pull request ensures that malformed self-closing tags are reported.

To solve this issue, the `XmlTagState` handler looks into the `context.Statetag` value `MAYBE_SELF_CLOSING`.
In that case, no other characters than `>` are accepted.

I noticed that the current code has the same value for two different state tags.
Essentially, I changed the assignments like thus:

```patch
		const int ATTEMPT_RECOVERY = 1;
		const int RECOVERY_FOUND_WHITESPACE = 2;
-		const int MAYBE_SELF_CLOSING = 2;
+		const int MAYBE_SELF_CLOSING = 3;
		const int FREE = 0;
```

I’m not sure what other impacts this has on the code, but all unit-tests are green, so 🤷.